### PR TITLE
Add script to convert Heroku JSON Schema to OpenAPI spec

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+import yaml
+import json
+import os
+import re
+from urllib.parse import unquote
+
+INPUT_SCHEMA_FILE = 'schema.json'
+PROVIDER_NAME = 'heroku'
+VERSION = 'v0'
+OUTPUT_DIR = os.path.join('provider', PROVIDER_NAME, VERSION)
+SERVICES_DIR = os.path.join(OUTPUT_DIR, 'services')
+
+# Heroku's schema has over 100 resources and a lot of them are connected, they will be mapped together
+# into a smaller set of files. (E.G., 'app' AND 'team-app' both go into 'apps.yaml').
+RESOURCE_SERVICE_MAP = {
+    'app': 'apps', 'team-app': 'apps', 'app-feature': 'apps', 'app-setup': 'apps', 'app-transfer': 'apps',
+    'app-webhook': 'apps', 'app-webhook-delivery': 'apps', 'app-webhook-event': 'apps',
+    'addon': 'addons', 'add-on': 'addons', 'add-on-attachment': 'addons', 'add-on-service': 'addons',
+    'plan': 'addons', 'allowed-add-on-service': 'addons', 'add-on-config': 'addons', 'add-on-action': 'addons',
+    'build': 'builds', 'buildpack-installation': 'builds',
+    'config-var': 'config_vars',
+    'dyno': 'dynos', 'dyno-size': 'dynos', 'formation': 'dynos',
+    'log-drain': 'logging', 'log-session': 'logging',
+    'release': 'releases', 'slug': 'releases', 'oci-image': 'releases',
+    'account': 'accounts', 'account-feature': 'accounts',
+    'team': 'teams', 'team-member': 'teams', 'team-invitation': 'teams', 'team-feature': 'teams',
+    'collaborator': 'collaborators', 'team-app-collaborator': 'collaborators',
+    'domain': 'domains', 'sni-endpoint': 'domains',
+    'key': 'keys',
+    'oauth-authorization': 'oauth', 'oauth-client': 'oauth', 'oauth-token': 'oauth', 'oauth-grant': 'oauth',
+    'pipeline': 'pipelines', 'pipeline-coupling': 'pipelines', 'pipeline-promotion': 'pipelines',
+    'pipeline-release': 'pipelines', 'pipeline-deployment': 'pipelines',
+    'region': 'platform', 'stack': 'platform',
+    'space': 'spaces', 'vpn-connection': 'networking', 'peering': 'networking',
+    'default': 'misc'
+}
+
+def sanitize_name(name, capitalize=False):
+    name = re.sub(r'[^a-zA-Z0-9_]', '_', name)
+    name = name.strip('_')
+    if capitalize:
+        return "".join(word.capitalize() for word in name.split('_'))
+    return name
+
+def get_service_name_for_resource(resource_name):
+    return RESOURCE_SERVICE_MAP.get(resource_name, 'misc')
+
+def create_base_spec(service_name, heroku_schema):
+    """Generates boilerplate"""
+    return {
+        "openapi": "3.0.0",
+        "info": {
+            "title": f"Heroku Platform API - {service_name.replace('_', ' ').title()}",
+            "description": heroku_schema.get('description', f"Operations related to Heroku {service_name}."),
+            "version": VERSION
+        },
+        "servers": [{"url": "https://api.heroku.com"}],
+        "paths": {},
+        "components": {
+            "schemas": {},
+            "securitySchemes": {
+                "herokuAuth": {"type": "http", "scheme": "bearer", "bearerFormat": "API Key"}
+            }
+        },
+        "security": [{"herokuAuth": []}]
+    }
+
+def clean_schema_object(obj):
+    """Removes non-OpenAPI keys from a schema object that would otherwise make the final specification invalid"""
+    if not isinstance(obj, dict):
+        return
+    invalid_keys = ['links', 'definitions', 'stability', 'strictProperties', '$schema', 'title', 'example']
+    for key in invalid_keys:
+        if key in obj:
+            del obj[key]
+    
+    for key in list(obj.keys()):
+        if isinstance(obj[key], (dict, list)):
+            # remove all nested invalid keys with recursion
+            clean_schema_object(obj[key])
+
+def rewrite_refs_recursive(obj, service_spec, heroku_schema):
+    """Rewrites internal references in valid OpenAPI"""
+    """find every $ref, locate the original definition it points to, copy that definition to the correct
+    central location (/components/schemas/), and then update the $ref to point to that new location."""
+    if isinstance(obj, dict):
+        if '$ref' in obj and obj['$ref'].startswith('#/definitions/'):
+            original_ref = obj['$ref']
+            parts = original_ref.split('/')
+            
+            # Case 1: #/definitions/resource/definitions/schema
+            if len(parts) >= 5 and parts[3] == 'definitions':
+                resource_name = parts[2]
+                schema_name = parts[4]
+                if schema_name not in service_spec['components']['schemas']:
+                    if resource_name in heroku_schema['definitions'] and \
+                       'definitions' in heroku_schema['definitions'][resource_name] and \
+                       schema_name in heroku_schema['definitions'][resource_name]['definitions']:
+                        # original schema object
+                        schema_def = heroku_schema['definitions'][resource_name]['definitions'][schema_name]
+                        service_spec['components']['schemas'][schema_name] = schema_def
+                        clean_schema_object(service_spec['components']['schemas'][schema_name])
+                        rewrite_refs_recursive(service_spec['components']['schemas'][schema_name], service_spec, heroku_schema)
+                obj['$ref'] = f"#/components/schemas/{schema_name}"
+            # Case 2: #/definitions/resource
+            else:
+                schema_name = parts[-1]
+                if schema_name not in service_spec['components']['schemas']:
+                     if schema_name in heroku_schema['definitions']:
+                        schema_def = dict(heroku_schema['definitions'][schema_name])
+                        service_spec['components']['schemas'][schema_name] = schema_def
+                        clean_schema_object(service_spec['components']['schemas'][schema_name])
+                        rewrite_refs_recursive(service_spec['components']['schemas'][schema_name], service_spec, heroku_schema)
+                obj['$ref'] = f"#/components/schemas/{schema_name}"
+        
+        for key, value in list(obj.items()):
+            rewrite_refs_recursive(value, service_spec, heroku_schema)
+
+    elif isinstance(obj, list):
+        for item in obj:
+            rewrite_refs_recursive(item, service_spec, heroku_schema)
+
+def map_rel_to_sql_verb(rel):
+    """Translate to a corresponding SQL verb"""
+    if rel in ["instances", "self"]: return "select"
+    if rel == "create": return "insert"
+    if rel == "update": return "update"
+    if rel in ["destroy", "delete"]: return "delete"
+    return "exec"
+
+def process_heroku_schema():
+    with open(INPUT_SCHEMA_FILE, 'r') as f:
+        heroku_schema = json.load(f)
+
+    service_specs = {}
+
+    for resource_name, resource_def in heroku_schema['definitions'].items():
+        service_name = get_service_name_for_resource(resource_name)
+        if service_name not in service_specs:
+            service_specs[service_name] = create_base_spec(service_name, heroku_schema)
+        spec = service_specs[service_name]
+        
+        if 'links' not in resource_def:
+            continue
+            
+        for link in resource_def['links']:
+            path_params = []
+            path = unquote(link['href'])
+            
+            def repl(m):
+                # Generate a more unique parameter name
+                # OpenAPI: every parameter in a given path must have a unique name
+                pointer = m.group(1)
+                base_name = pointer.split('/')[-1].replace(')','').replace('(','')
+                resource_context = pointer.split('/')[2] if len(pointer.split('/')) > 2 else base_name
+                param_name = sanitize_name(f"{resource_context}_{base_name}")
+                
+                # Avoid creating duplicate parameter objects for the same path
+                if not any(p['name'] == param_name for p in path_params):
+                    path_params.append({
+                        "name": param_name, "in": "path", "required": True,
+                        "schema": {"type": "string"}, "description": f"Unique identifier for {base_name} of {resource_context}."
+                    })
+                return f"{{{param_name}}}"
+
+            path = re.sub(r'{\(([^)]+)\)}', repl, path)
+            
+            method = link['method'].lower()
+            op_title = sanitize_name(link.get('title', link.get('rel', 'untitled')), capitalize=True)
+    
+            operation = {
+                "summary": link.get('title', 'No summary provided'),
+                "description": link.get('description', ''),
+                "operationId": f"{sanitize_name(resource_name)}{op_title}",
+                "tags": [service_name],
+                "parameters": path_params,
+                "responses": {},
+                "x-stackQL-resource": resource_name,
+                "x-stackQL-method": op_title,
+                "x-stackQL-verb": map_rel_to_sql_verb(link.get('rel', 'exec'))
+            }
+
+            if 'schema' in link:
+                operation['requestBody'] = {"required": True, "content": {"application/json": {"schema": link['schema']}}}
+
+            status_code = '200'
+            if method == 'post' and link.get('rel') == 'create': status_code = '201'
+            elif method == 'delete': status_code = '204'
+
+            description = "Successful operation"
+            if status_code == '201': description = "Created"
+            if status_code == '204': description = "No Content"
+
+            if 'targetSchema' in link and status_code != '204':
+                operation['responses'][status_code] = {"description": description, "content": {"application/json": {"schema": link['targetSchema']}}}
+            else:
+                 operation['responses'][status_code] = {"description": description}
+
+            if path not in spec['paths']: spec['paths'][path] = {}
+            spec['paths'][path][method] = operation
+
+    for service_name, spec in service_specs.items():
+        # fix all references
+        rewrite_refs_recursive(spec, spec, heroku_schema)
+        
+        # bulid the x-stackQL-references block
+        resources = {}
+        for path, path_obj in spec['paths'].items():
+            for verb, op in path_obj.items():
+                res_name, meth_name, sql_verb = op['x-stackQL-resource'], op['x-stackQL-method'], op['x-stackQL-verb']
+                if res_name not in resources:
+                    resources[res_name] = {
+                        "id": f"{PROVIDER_NAME}.{service_name}.{res_name}", "name": res_name, "title": res_name.replace('-', ' ').title(),
+                        "methods": {}, "sqlVerbs": {"select": [], "insert": [], "update": [], "delete": [], "exec": []}
+                    }
+                
+                path_ref = path.replace("/", "~1")
+                resources[res_name]['methods'][meth_name] = {
+                    "operation": {"$ref": f"#/paths/{path_ref}/{verb}"},
+                    "response": {"mediaType": "application/json", "openAPIDocKey": next(iter(op['responses']))}
+                }
+                
+                method_ref = f"#/components/x-stackQL-resources/{res_name}/methods/{meth_name}"
+                if sql_verb in resources[res_name]['sqlVerbs']:
+                    resources[res_name]['sqlVerbs'][sql_verb].append({"$ref": method_ref})
+
+        spec['components']['x-stackQL-resources'] = resources
+
+    # write all files
+    os.makedirs(SERVICES_DIR, exist_ok=True)
+    for service_name, spec in service_specs.items():
+        output_path = os.path.join(SERVICES_DIR, f"{service_name}.yaml")
+        with open(output_path, 'w') as f:
+            yaml.dump(spec, f, sort_keys=False, default_flow_style=False, width=120)
+
+    # generate provider
+    provider_manifest = {
+        "id": PROVIDER_NAME, "name": PROVIDER_NAME, "version": VERSION,
+        "providerServices": {},
+        "config": {"auth": {"type": "bearer", "credentialsenvvar": "HEROKU_API_TOKEN"}}
+    }
+    for service_name in sorted(service_specs.keys()):
+        provider_manifest['providerServices'][service_name] = {
+            "id": f"{service_name}:{VERSION}", "name": service_name, "preferred": True,
+            "service": {"$ref": f"{PROVIDER_NAME}/{VERSION}/services/{service_name}.yaml"},
+            "title": f"Heroku {service_name.replace('_', ' ').title()}",
+            "version": VERSION, "description": service_specs[service_name]['info']['description']
+        }
+    
+    manifest_path = os.path.join(OUTPUT_DIR, 'provider.yaml')
+    with open(manifest_path, 'w') as f:
+        yaml.dump(provider_manifest, f, sort_keys=False, default_flow_style=False, width=120)
+
+
+if __name__ == "__main__":
+    process_heroku_schema()

--- a/provider/heroku/v0/provider.yaml
+++ b/provider/heroku/v0/provider.yaml
@@ -1,0 +1,172 @@
+id: heroku
+name: heroku
+version: v0
+providerServices:
+  accounts:
+    id: accounts:v0
+    name: accounts
+    preferred: true
+    service:
+      $ref: heroku/v0/services/accounts.yaml
+    title: Heroku Accounts
+    version: v0
+    description: Manage Heroku user accounts and account-level features.
+  addons:
+    id: addons:v0
+    name: addons
+    preferred: true
+    service:
+      $ref: heroku/v0/services/addons.yaml
+    title: Heroku Addons
+    version: v0
+    description: Provision, manage, and inspect Heroku add-ons and their associated plans.
+  apps:
+    id: apps:v0
+    name: apps
+    preferred: true
+    service:
+      $ref: heroku/v0/services/apps.yaml
+    title: Heroku Apps
+    version: v0
+    description: Create and manage Heroku applications, including setup, transfers, and webhooks.
+  builds:
+    id: builds:v0
+    name: builds
+    preferred: true
+    service:
+      $ref: heroku/v0/services/builds.yaml
+    title: Heroku Builds
+    version: v0
+    description: Manage app builds and buildpack configurations.
+  collaborators:
+    id: collaborators:v0
+    name: collaborators
+    preferred: true
+    service:
+      $ref: heroku/v0/services/collaborators.yaml
+    title: Heroku Collaborators
+    version: v0
+    description: Manage user access and collaboration on applications.
+  config_vars:
+    id: config_vars:v0
+    name: config_vars
+    preferred: true
+    service:
+      $ref: heroku/v0/services/config_vars.yaml
+    title: Heroku Config Vars
+    version: v0
+    description: View and manage application configuration variables.
+  domains:
+    id: domains:v0
+    name: domains
+    preferred: true
+    service:
+      $ref: heroku/v0/services/domains.yaml
+    title: Heroku Domains
+    version: v0
+    description: Manage custom domains and SNI endpoints for Heroku apps.
+  dynos:
+    id: dynos:v0
+    name: dynos
+    preferred: true
+    service:
+      $ref: heroku/v0/services/dynos.yaml
+    title: Heroku Dynos
+    version: v0
+    description: Manage application dynos, including scaling, restarting, and viewing available sizes.
+  keys:
+    id: keys:v0
+    name: keys
+    preferred: true
+    service:
+      $ref: heroku/v0/services/keys.yaml
+    title: Heroku Keys
+    version: v0
+    description: Manage SSH keys associated with a Heroku account for git operations.
+  logging:
+    id: logging:v0
+    name: logging
+    preferred: true
+    service:
+      $ref: heroku/v0/services/logging.yaml
+    title: Heroku Logging
+    version: v0
+    description: Manage log drains and create log streaming sessions for applications.
+  misc:
+    id: misc:v0
+    name: misc
+    preferred: true
+    service:
+      $ref: heroku/v0/services/misc.yaml
+    title: Heroku Misc
+    version: v0
+    description: Miscellaneous and uncategorized Heroku API operations.
+  networking:
+    id: networking:v0
+    name: networking
+    preferred: true
+    service:
+      $ref: heroku/v0/services/networking.yaml
+    title: Heroku Networking
+    version: v0
+    description: Manage Private Space networking, including VPC peering and VPN connections.
+  oauth:
+    id: oauth:v0
+    name: oauth
+    preferred: true
+    service:
+      $ref: heroku/v0/services/oauth.yaml
+    title: Heroku Oauth
+    version: v0
+    description: Manage OAuth clients, authorizations, and tokens for API access.
+  pipelines:
+    id: pipelines:v0
+    name: pipelines
+    preferred: true
+    service:
+      $ref: heroku/v0/services/pipelines.yaml
+    title: Heroku Pipelines
+    version: v0
+    description: Manage CI/CD pipelines, promotions, and couplings between applications.
+  platform:
+    id: platform:v0
+    name: platform
+    preferred: true
+    service:
+      $ref: heroku/v0/services/platform.yaml
+    title: Heroku Platform
+    version: v0
+    description: View available regions and stacks on the Heroku platform.
+  releases:
+    id: releases:v0
+    name: releases
+    preferred: true
+    service:
+      $ref: heroku/v0/services/releases.yaml
+    title: Heroku Releases
+    version: v0
+    description: Manage application releases, slugs, and OCI images for deployments.
+  spaces:
+    id: spaces:v0
+    name: spaces
+    preferred: true
+    service:
+      $ref: heroku/v0/services/spaces.yaml
+    title: Heroku Spaces
+    version: v0
+    description: Manage Private Spaces for isolated application execution environments.
+  teams:
+    id: teams:v0
+    name: teams
+    preferred: true
+    service:
+      $ref: heroku/v0/services/teams.yaml
+    title: Heroku Teams
+    version: v0
+    description: Manage teams, members, and team-level features and invitations.
+config:
+  auth:
+    type: bearer
+    credentialsenvvar: HEROKU_API_TOKEN
+    scheme: bearer
+    doc_url: https://devcenter.heroku.com/articles/platform-api-quickstart#authentication

--- a/provider/heroku/v0/services/accounts.yaml
+++ b/provider/heroku/v0/services/accounts.yaml
@@ -1,0 +1,497 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Accounts
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /account/features/{account_feature_identity}:
+    get:
+      summary: Info
+      description: Info for an existing account feature.
+      operationId: account_featureInfo
+      tags:
+      - accounts
+      parameters:
+      - name: account_feature_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account-feature.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/account-feature'
+      x-stackQL-resource: account-feature
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update an existing account feature.
+      operationId: account_featureUpdate
+      tags:
+      - accounts
+      parameters:
+      - name: account_feature_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account-feature.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/account-feature'
+      x-stackQL-resource: account-feature
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                enabled:
+                  $ref: '#/components/schemas/enabled'
+              required:
+              - enabled
+              type:
+              - object
+  /account/features:
+    get:
+      summary: List
+      description: List existing account features.
+      operationId: account_featureList
+      tags:
+      - accounts
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/account-feature'
+                type:
+                - array
+      x-stackQL-resource: account-feature
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /account:
+    get:
+      summary: Info
+      description: Info for account.
+      operationId: accountInfo
+      tags:
+      - accounts
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/account'
+      x-stackQL-resource: account
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update account.
+      operationId: accountUpdate
+      tags:
+      - accounts
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/account'
+      x-stackQL-resource: account
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                allow_tracking:
+                  $ref: '#/components/schemas/allow_tracking'
+                beta:
+                  $ref: '#/components/schemas/beta'
+                name:
+                  $ref: '#/components/schemas/name'
+              type:
+              - object
+    delete:
+      summary: Delete
+      description: 'Delete account. Note that this action cannot be undone. Note: This endpoint requires the HTTP_HEROKU_PASSWORD
+        or HTTP_HEROKU_PASSWORD_BASE64 header be set correctly for the user account.'
+      operationId: accountDelete
+      tags:
+      - accounts
+      parameters: []
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: account
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+  /users/{account_identity}:
+    get:
+      summary: Info By User
+      description: Info for account.
+      operationId: accountInfoByUser
+      tags:
+      - accounts
+      parameters:
+      - name: account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/account'
+      x-stackQL-resource: account
+      x-stackQL-method: InfoByUser
+      x-stackQL-verb: select
+    patch:
+      summary: Update By User
+      description: Update account.
+      operationId: accountUpdateByUser
+      tags:
+      - accounts
+      parameters:
+      - name: account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/account'
+      x-stackQL-resource: account
+      x-stackQL-method: UpdateByUser
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                allow_tracking:
+                  $ref: '#/components/schemas/allow_tracking'
+                beta:
+                  $ref: '#/components/schemas/beta'
+                name:
+                  $ref: '#/components/schemas/name'
+              type:
+              - object
+    delete:
+      summary: Delete By User
+      description: 'Delete account. Note that this action cannot be undone. Note: This endpoint requires the HTTP_HEROKU_PASSWORD
+        or HTTP_HEROKU_PASSWORD_BASE64 header be set correctly for the user account.'
+      operationId: accountDeleteByUser
+      tags:
+      - accounts
+      parameters:
+      - name: account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: account
+      x-stackQL-method: DeleteByUser
+      x-stackQL-verb: delete
+components:
+  schemas:
+    account-feature:
+      description: An account feature represents a Heroku labs capability that can be enabled or disabled for an account on
+        Heroku.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        description:
+          $ref: '#/components/schemas/description'
+        doc_url:
+          $ref: '#/components/schemas/doc_url'
+        enabled:
+          $ref: '#/components/schemas/enabled'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        state:
+          $ref: '#/components/schemas/state'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        display_name:
+          $ref: '#/components/schemas/display_name'
+        feedback_email:
+          $ref: '#/components/schemas/feedback_email'
+    created_at:
+      description: when account feature was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    description:
+      description: description of account feature
+      readOnly: true
+      type:
+      - string
+    doc_url:
+      description: documentation URL of account feature
+      readOnly: true
+      type:
+      - string
+    enabled:
+      description: whether or not account feature has been enabled
+      readOnly: false
+      type:
+      - boolean
+    id:
+      description: unique identifier of account feature
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    name:
+      description: unique name of account feature
+      readOnly: true
+      type:
+      - string
+    state:
+      description: state of account feature
+      readOnly: true
+      type:
+      - string
+    updated_at:
+      description: when account feature was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    display_name:
+      description: user readable feature name
+      readOnly: true
+      type:
+      - string
+    feedback_email:
+      description: e-mail to send feedback about the feature
+      readOnly: true
+      type:
+      - string
+    account:
+      description: An account represents an individual signed up to use the Heroku platform.
+      type:
+      - object
+      properties:
+        allow_tracking:
+          $ref: '#/components/schemas/allow_tracking'
+        beta:
+          $ref: '#/components/schemas/beta'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        email:
+          $ref: '#/components/schemas/email'
+        federated:
+          $ref: '#/components/schemas/federated'
+        id:
+          $ref: '#/components/schemas/id'
+        identity_provider:
+          description: Identity Provider details for federated users.
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+            team:
+              type:
+              - object
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+            organization:
+              type:
+              - object
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+            owner:
+              $ref: '#/components/schemas/owner'
+          type:
+          - object
+          - 'null'
+        last_login:
+          $ref: '#/components/schemas/last_login'
+        name:
+          $ref: '#/components/schemas/name'
+        sms_number:
+          $ref: '#/components/schemas/sms_number'
+        suspended_at:
+          $ref: '#/components/schemas/suspended_at'
+        delinquent_at:
+          $ref: '#/components/schemas/delinquent_at'
+        two_factor_authentication:
+          $ref: '#/components/schemas/two_factor_authentication'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        verified:
+          $ref: '#/components/schemas/verified'
+        country_of_residence:
+          $ref: '#/components/schemas/country_of_residence'
+        default_organization:
+          description: team selected by default
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+          - 'null'
+        default_team:
+          description: team selected by default
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+          - 'null'
+    allow_tracking:
+      default: true
+      description: whether to allow third party web activity tracking
+      readOnly: false
+      type:
+      - boolean
+    beta:
+      default: false
+      description: whether allowed to utilize beta Heroku features
+      readOnly: false
+      type:
+      - boolean
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    account-feature:
+      id: heroku.accounts.account-feature
+      name: account-feature
+      title: Account Feature
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1account~1features~1{account_feature_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1account~1features~1{account_feature_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1account~1features/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/account-feature/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/account-feature/methods/List'
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/account-feature/methods/Update'
+        delete: []
+        exec: []
+    account:
+      id: heroku.accounts.account
+      name: account
+      title: Account
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1account/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1account/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1account/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        InfoByUser:
+          operation:
+            $ref: '#/paths/~1users~1{account_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        UpdateByUser:
+          operation:
+            $ref: '#/paths/~1users~1{account_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        DeleteByUser:
+          operation:
+            $ref: '#/paths/~1users~1{account_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/account/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/account/methods/InfoByUser'
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/account/methods/Update'
+        - $ref: '#/components/x-stackQL-resources/account/methods/UpdateByUser'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/account/methods/Delete'
+        - $ref: '#/components/x-stackQL-resources/account/methods/DeleteByUser'
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/addons.yaml
+++ b/provider/heroku/v0/services/addons.yaml
@@ -1,0 +1,1590 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Addons
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /addons/{add_on_identity}/actions/provision:
+    post:
+      summary: Provision
+      description: Mark an add-on as provisioned for use.
+      operationId: add_on_actionProvision
+      tags:
+      - addons
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add-on'
+      x-stackQL-resource: add-on-action
+      x-stackQL-method: Provision
+      x-stackQL-verb: update
+  /addons/{add_on_identity}/actions/deprovision:
+    post:
+      summary: Deprovision
+      description: Mark an add-on as deprovisioned.
+      operationId: add_on_actionDeprovision
+      tags:
+      - addons
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add-on'
+      x-stackQL-resource: add-on-action
+      x-stackQL-method: Deprovision
+      x-stackQL-verb: update
+  /addon-attachments:
+    post:
+      summary: Create
+      description: Create a new add-on attachment.
+      operationId: add_on_attachmentCreate
+      tags:
+      - addons
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add-on-attachment'
+      x-stackQL-resource: add-on-attachment
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                addon:
+                  $ref: '#/components/schemas/identity'
+                app:
+                  $ref: '#/components/schemas/identity'
+                confirm:
+                  $ref: '#/components/schemas/confirm'
+                name:
+                  $ref: '#/components/schemas/name'
+                namespace:
+                  $ref: '#/components/schemas/namespace'
+              required:
+              - addon
+              - app
+              type:
+              - object
+    get:
+      summary: List
+      description: List existing add-on attachments.
+      operationId: add_on_attachmentList
+      tags:
+      - addons
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on-attachment'
+                type:
+                - array
+      x-stackQL-resource: add-on-attachment
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /addon-attachments/{add_on_attachment_identity}:
+    delete:
+      summary: Delete
+      description: Delete an existing add-on attachment.
+      operationId: add_on_attachmentDelete
+      tags:
+      - addons
+      parameters:
+      - name: add_on_attachment_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on-attachment.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: add-on-attachment
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Info for existing add-on attachment.
+      operationId: add_on_attachmentInfo
+      tags:
+      - addons
+      parameters:
+      - name: add_on_attachment_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on-attachment.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add-on-attachment'
+      x-stackQL-resource: add-on-attachment
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /addons/{add_on_identity}/addon-attachments:
+    get:
+      summary: List by Add-on
+      description: List existing add-on attachments for an add-on.
+      operationId: add_on_attachmentListByAddOn
+      tags:
+      - addons
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on-attachment'
+                type:
+                - array
+      x-stackQL-resource: add-on-attachment
+      x-stackQL-method: ListByAddOn
+      x-stackQL-verb: select
+  /apps/{app_identity}/addon-attachments:
+    get:
+      summary: List by App
+      description: List existing add-on attachments for an app.
+      operationId: add_on_attachmentListByApp
+      tags:
+      - addons
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on-attachment'
+                type:
+                - array
+      x-stackQL-resource: add-on-attachment
+      x-stackQL-method: ListByApp
+      x-stackQL-verb: select
+  /apps/{app_identity}/addon-attachments/{add_on_attachment_scopedIdentity}:
+    get:
+      summary: Info by App
+      description: Info for existing add-on attachment for an app.
+      operationId: add_on_attachmentInfoByApp
+      tags:
+      - addons
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: add_on_attachment_scopedIdentity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for scopedIdentity of add-on-attachment.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add-on-attachment'
+      x-stackQL-resource: add-on-attachment
+      x-stackQL-method: InfoByApp
+      x-stackQL-verb: select
+  /actions/addon-attachments/resolve:
+    post:
+      summary: Resolution
+      description: Resolve an add-on attachment from a name, optionally passing an app name. If there are matches it returns
+        at least one add-on attachment (exact match) or many.
+      operationId: add_on_attachmentResolution
+      tags:
+      - addons
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on-attachment'
+                type:
+                - array
+      x-stackQL-resource: add-on-attachment
+      x-stackQL-method: Resolution
+      x-stackQL-verb: exec
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                addon_attachment:
+                  $ref: '#/components/schemas/name'
+                app:
+                  $ref: '#/components/schemas/name'
+                addon_service:
+                  $ref: '#/components/schemas/name'
+              required:
+              - addon_attachment
+              type:
+              - object
+  /addons/{add_on_identity}/config:
+    get:
+      summary: List
+      description: Get an add-on's config. Accessible by customers with access and by the add-on partner providing this add-on.
+      operationId: add_on_configList
+      tags:
+      - addons
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on-config'
+                type:
+                - array
+      x-stackQL-resource: add-on-config
+      x-stackQL-method: List
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update an add-on's config. Can only be accessed by the add-on partner providing this add-on.
+      operationId: add_on_configUpdate
+      tags:
+      - addons
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type:
+                - array
+                items:
+                  $ref: '#/components/schemas/add-on-config'
+      x-stackQL-resource: add-on-config
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                config:
+                  items:
+                    $ref: '#/components/schemas/add-on-config'
+                  type:
+                  - array
+              type:
+              - object
+  /addon-services/{add_on_service_identity}:
+    get:
+      summary: Info
+      description: Info for existing add-on-service.
+      operationId: add_on_serviceInfo
+      tags:
+      - addons
+      parameters:
+      - name: add_on_service_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on-service.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add-on-service'
+      x-stackQL-resource: add-on-service
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /addon-services:
+    get:
+      summary: List
+      description: List existing add-on-services.
+      operationId: add_on_serviceList
+      tags:
+      - addons
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on-service'
+                type:
+                - array
+      x-stackQL-resource: add-on-service
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /addons:
+    get:
+      summary: List
+      description: List all existing add-ons.
+      operationId: add_onList
+      tags:
+      - addons
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on'
+                type:
+                - array
+      x-stackQL-resource: add-on
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /addons/{add_on_identity}:
+    get:
+      summary: Info
+      description: Info for an existing add-on.
+      operationId: add_onInfo
+      tags:
+      - addons
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add-on'
+      x-stackQL-resource: add-on
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /apps/{app_identity}/addons:
+    post:
+      summary: Create
+      description: Create a new add-on.
+      operationId: add_onCreate
+      tags:
+      - addons
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add-on'
+      x-stackQL-resource: add-on
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                attachment:
+                  description: name for add-on's initial attachment
+                  example:
+                    name: DATABASE_FOLLOWER
+                  properties:
+                    name:
+                      $ref: '#/components/schemas/name'
+                  type:
+                  - object
+                config:
+                  $ref: '#/components/schemas/config'
+                confirm:
+                  $ref: '#/components/schemas/confirm'
+                plan:
+                  $ref: '#/components/schemas/identity'
+                name:
+                  $ref: '#/components/schemas/name'
+              required:
+              - plan
+              type:
+              - object
+    get:
+      summary: List By App
+      description: List existing add-ons for an app.
+      operationId: add_onListByApp
+      tags:
+      - addons
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on'
+                type:
+                - array
+      x-stackQL-resource: add-on
+      x-stackQL-method: ListByApp
+      x-stackQL-verb: select
+  /apps/{app_identity}/addons/{add_on_identity}:
+    delete:
+      summary: Delete
+      description: Delete an existing add-on.
+      operationId: add_onDelete
+      tags:
+      - addons
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: add-on
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info By App
+      description: Info for an existing add-on.
+      operationId: add_onInfoByApp
+      tags:
+      - addons
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add-on'
+      x-stackQL-resource: add-on
+      x-stackQL-method: InfoByApp
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Change add-on plan. Some add-ons may not support changing plans. In that case, an error will be returned.
+      operationId: add_onUpdate
+      tags:
+      - addons
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/add-on'
+      x-stackQL-resource: add-on
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+                plan:
+                  $ref: '#/components/schemas/identity'
+              required:
+              - plan
+              type:
+              - object
+  /users/{account_identity}/addons:
+    get:
+      summary: List By User
+      description: List all existing add-ons a user has access to
+      operationId: add_onListByUser
+      tags:
+      - addons
+      parameters:
+      - name: account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on'
+                type:
+                - array
+      x-stackQL-resource: add-on
+      x-stackQL-method: ListByUser
+      x-stackQL-verb: select
+  /teams/{team_identity}/addons:
+    get:
+      summary: List By Team
+      description: List add-ons used across all Team apps
+      operationId: add_onListByTeam
+      tags:
+      - addons
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on'
+                type:
+                - array
+      x-stackQL-resource: add-on
+      x-stackQL-method: ListByTeam
+      x-stackQL-verb: select
+  /actions/addons/resolve:
+    post:
+      summary: Resolution
+      description: Resolve an add-on from a name, optionally passing an app name. If there are matches it returns at least
+        one add-on (exact match) or many.
+      operationId: add_onResolution
+      tags:
+      - addons
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on'
+                type:
+                - array
+      x-stackQL-resource: add-on
+      x-stackQL-method: Resolution
+      x-stackQL-verb: exec
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                addon:
+                  $ref: '#/components/schemas/name'
+                app:
+                  $ref: '#/components/schemas/name'
+                addon_service:
+                  $ref: '#/components/schemas/name'
+              required:
+              - addon
+              type:
+              - object
+  /teams/{team_identity}/allowed-addon-services:
+    get:
+      summary: List By Team
+      description: List all allowed add-on services for a team
+      operationId: allowed_add_on_serviceListByTeam
+      tags:
+      - addons
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/allowed-add-on-service'
+                type:
+                - array
+      x-stackQL-resource: allowed-add-on-service
+      x-stackQL-method: ListByTeam
+      x-stackQL-verb: select
+    post:
+      summary: Create By Team
+      description: Allow an Add-on Service
+      operationId: allowed_add_on_serviceCreateByTeam
+      tags:
+      - addons
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/allowed-add-on-service'
+                type:
+                - array
+      x-stackQL-resource: allowed-add-on-service
+      x-stackQL-method: CreateByTeam
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type:
+              - object
+              properties:
+                addon_service:
+                  description: name of the add-on service to allow
+                  example: heroku-postgresql
+                  type:
+                  - string
+  /teams/{team_identity}/allowed-addon-services/{allowed_add_on_service_identity}:
+    delete:
+      summary: Delete By Team
+      description: Remove an allowed add-on service
+      operationId: allowed_add_on_serviceDeleteByTeam
+      tags:
+      - addons
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      - name: allowed_add_on_service_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of allowed-add-on-service.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: allowed-add-on-service
+      x-stackQL-method: DeleteByTeam
+      x-stackQL-verb: delete
+  /plans/{plan_identity}:
+    get:
+      summary: Info
+      description: Info for existing plan.
+      operationId: planInfo
+      tags:
+      - addons
+      parameters:
+      - name: plan_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of plan.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/plan'
+      x-stackQL-resource: plan
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /addon-services/{add_on_service_identity}/plans/{plan_identity}:
+    get:
+      summary: Info By Add-on
+      description: Info for existing plan by Add-on.
+      operationId: planInfoByAddOn
+      tags:
+      - addons
+      parameters:
+      - name: add_on_service_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on-service.
+      - name: plan_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of plan.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/plan'
+      x-stackQL-resource: plan
+      x-stackQL-method: InfoByAddOn
+      x-stackQL-verb: select
+  /addon-services/{add_on_service_identity}/plans:
+    get:
+      summary: List By Add-on
+      description: List existing plans by Add-on.
+      operationId: planListByAddOn
+      tags:
+      - addons
+      parameters:
+      - name: add_on_service_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on-service.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/plan'
+                type:
+                - array
+      x-stackQL-resource: plan
+      x-stackQL-method: ListByAddOn
+      x-stackQL-verb: select
+components:
+  schemas:
+    add-on:
+      description: Add-ons represent add-ons that have been provisioned and attached to one or more apps.
+      additionalProperties: false
+      required:
+      - actions
+      - addon_service
+      - billing_entity
+      - app
+      - billed_price
+      - config_vars
+      - created_at
+      - id
+      - name
+      - plan
+      - provider_id
+      - state
+      - updated_at
+      - web_url
+      type:
+      - object
+      properties:
+        actions:
+          $ref: '#/components/schemas/actions'
+        addon_service:
+          $ref: '#/components/schemas/addon_service'
+        billing_entity:
+          description: billing entity associated with this add-on
+          type:
+          - object
+          properties:
+            id:
+              description: unique identifier of the billing entity
+              format: uuid
+              readOnly: true
+              type:
+              - string
+            name:
+              description: name of the billing entity
+              readOnly: true
+              type:
+              - string
+            type:
+              description: type of Object of the billing entity; new types allowed at any time.
+              enum:
+              - app
+              - team
+              readOnly: true
+              type:
+              - string
+        app:
+          description: billing application associated with this add-on
+          type:
+          - object
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+        billed_price:
+          description: billed price
+          properties:
+            cents:
+              $ref: '#/components/schemas/cents'
+            contract:
+              $ref: '#/components/schemas/contract'
+            unit:
+              $ref: '#/components/schemas/unit'
+          type:
+          - object
+          - 'null'
+        config_vars:
+          $ref: '#/components/schemas/config_vars'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        plan:
+          $ref: '#/components/schemas/plan'
+        provider_id:
+          $ref: '#/components/schemas/provider_id'
+        provision_message:
+          $ref: '#/components/schemas/provision_message'
+        state:
+          $ref: '#/components/schemas/state'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        web_url:
+          $ref: '#/components/schemas/web_url'
+    add-on-attachment:
+      description: An add-on attachment represents a connection between an app and an add-on that it has been given access
+        to.
+      type:
+      - object
+      properties:
+        addon:
+          description: identity of add-on
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+            app:
+              description: billing application associated with this add-on
+              type:
+              - object
+              properties:
+                id:
+                  $ref: '#/components/schemas/id'
+                name:
+                  $ref: '#/components/schemas/name'
+          additionalProperties: false
+          required:
+          - id
+          - name
+          - app
+          type:
+          - object
+        app:
+          description: application that is attached to add-on
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        namespace:
+          $ref: '#/components/schemas/namespace'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        web_url:
+          $ref: '#/components/schemas/web_url'
+        log_input_url:
+          $ref: '#/components/schemas/log_input_url'
+    id:
+      description: unique identifier of add-on
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    name:
+      description: globally unique name of the add-on
+      pattern: ^[a-zA-Z][A-Za-z0-9_-]+$
+      type:
+      - string
+    created_at:
+      description: when add-on attachment was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    namespace:
+      description: attachment namespace
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    updated_at:
+      description: when add-on attachment was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    web_url:
+      description: URL for logging into web interface of add-on in attached app context
+      format: uri
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    log_input_url:
+      description: URL for add-on partners to write to an add-on's logs
+      type:
+      - 'null'
+      - string
+      readOnly: true
+    identity:
+      anyOf:
+      - $ref: '#/components/schemas/id'
+      - $ref: '#/components/schemas/name'
+    confirm:
+      description: name of owning app for confirmation
+      type:
+      - string
+    add-on-config:
+      description: Configuration of an Add-on
+      type:
+      - object
+      properties:
+        name:
+          $ref: '#/components/schemas/name'
+        value:
+          $ref: '#/components/schemas/value'
+    value:
+      description: value of the config
+      type:
+      - string
+      - 'null'
+    add-on-service:
+      description: Add-on services represent add-ons that may be provisioned for apps. Endpoints under add-on services can
+        be accessed without authentication.
+      type:
+      - object
+      properties:
+        cli_plugin_name:
+          $ref: '#/components/schemas/cli_plugin_name'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        human_name:
+          $ref: '#/components/schemas/human_name'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        state:
+          $ref: '#/components/schemas/state'
+        supports_multiple_installations:
+          $ref: '#/components/schemas/supports_multiple_installations'
+        supports_sharing:
+          $ref: '#/components/schemas/supports_sharing'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        supported_generations:
+          $ref: '#/components/schemas/supported_generations'
+    config:
+      additionalProperties: false
+      description: custom add-on provisioning options
+      patternProperties:
+        ^\w+$:
+          type:
+          - string
+      type:
+      - object
+    allowed-add-on-service:
+      description: Entities that have been allowed to be used by a Team
+      type:
+      - object
+      properties:
+        added_at:
+          $ref: '#/components/schemas/added_at'
+        added_by:
+          $ref: '#/components/schemas/added_by'
+        addon_service:
+          $ref: '#/components/schemas/addon_service'
+        id:
+          $ref: '#/components/schemas/id'
+    added_at:
+      description: when the add-on service was allowed
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    added_by:
+      description: the user which allowed the add-on service
+      properties:
+        email:
+          $ref: '#/components/schemas/email'
+          type:
+          - string
+          - 'null'
+        id:
+          $ref: '#/components/schemas/id'
+          type:
+          - string
+          - 'null'
+      readOnly: true
+      type:
+      - object
+    email:
+      description: unique email address of account
+      format: email
+      readOnly: false
+      type:
+      - string
+    addon_service:
+      description: the add-on service allowed for use
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        human_name:
+          $ref: '#/components/schemas/human_name'
+      readOnly: true
+      type:
+      - object
+    human_name:
+      description: human-readable name of the add-on service provider
+      readOnly: true
+      type:
+      - string
+    plan:
+      description: Plans represent different configurations of add-ons that may be added to apps. Endpoints under add-on services
+        can be accessed without authentication.
+      type:
+      - object
+      properties:
+        addon_service:
+          description: identity of add-on service
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        compliance:
+          $ref: '#/components/schemas/compliance'
+        default:
+          $ref: '#/components/schemas/default'
+        description:
+          $ref: '#/components/schemas/description'
+        human_name:
+          $ref: '#/components/schemas/human_name'
+        id:
+          $ref: '#/components/schemas/id'
+        installable_inside_private_network:
+          $ref: '#/components/schemas/installable_inside_private_network'
+        installable_outside_private_network:
+          $ref: '#/components/schemas/installable_outside_private_network'
+        name:
+          $ref: '#/components/schemas/name'
+        price:
+          description: price
+          properties:
+            cents:
+              $ref: '#/components/schemas/cents'
+            contract:
+              $ref: '#/components/schemas/contract'
+            unit:
+              $ref: '#/components/schemas/unit'
+          type:
+          - object
+        space_default:
+          $ref: '#/components/schemas/space_default'
+        state:
+          $ref: '#/components/schemas/state'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        visible:
+          $ref: '#/components/schemas/visible'
+    compliance:
+      description: the compliance regimes applied to an add-on plan
+      readOnly: false
+      type:
+      - 'null'
+      - array
+      items:
+        $ref: '#/components/schemas/regime'
+    regime:
+      description: compliance requirements an add-on plan must adhere to
+      readOnly: true
+      type:
+      - string
+      enum:
+      - HIPAA
+      - PCI
+    default:
+      description: whether this plan is the default for its add-on service
+      readOnly: true
+      type:
+      - boolean
+    description:
+      description: description of plan
+      readOnly: true
+      type:
+      - string
+    installable_inside_private_network:
+      description: whether this plan is installable to a Private Spaces app
+      readOnly: true
+      type:
+      - boolean
+    installable_outside_private_network:
+      description: whether this plan is installable to a Common Runtime app
+      readOnly: true
+      type:
+      - boolean
+    cents:
+      description: price in cents per unit of plan
+      readOnly: true
+      type:
+      - integer
+    contract:
+      description: price is negotiated in a contract outside of monthly add-on billing
+      readOnly: true
+      type:
+      - boolean
+    unit:
+      description: unit of price for plan
+      readOnly: true
+      type:
+      - string
+    space_default:
+      description: whether this plan is the default for apps in Private Spaces
+      readOnly: true
+      type:
+      - boolean
+    state:
+      description: release status for plan
+      readOnly: true
+      type:
+      - string
+    visible:
+      description: whether this plan is publicly visible
+      readOnly: true
+      type:
+      - boolean
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    add-on-action:
+      id: heroku.addons.add-on-action
+      name: add-on-action
+      title: Add On Action
+      methods:
+        Provision:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1actions~1provision/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Deprovision:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1actions~1deprovision/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select: []
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/add-on-action/methods/Provision'
+        - $ref: '#/components/x-stackQL-resources/add-on-action/methods/Deprovision'
+        delete: []
+        exec: []
+    add-on-attachment:
+      id: heroku.addons.add-on-attachment
+      name: add-on-attachment
+      title: Add On Attachment
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1addon-attachments/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1addon-attachments/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1addon-attachments~1{add_on_attachment_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1addon-attachments~1{add_on_attachment_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByAddOn:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1addon-attachments/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByApp:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1addon-attachments/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        InfoByApp:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1addon-attachments~1{add_on_attachment_scopedIdentity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Resolution:
+          operation:
+            $ref: '#/paths/~1actions~1addon-attachments~1resolve/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/add-on-attachment/methods/List'
+        - $ref: '#/components/x-stackQL-resources/add-on-attachment/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/add-on-attachment/methods/ListByAddOn'
+        - $ref: '#/components/x-stackQL-resources/add-on-attachment/methods/ListByApp'
+        - $ref: '#/components/x-stackQL-resources/add-on-attachment/methods/InfoByApp'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/add-on-attachment/methods/Create'
+        update: []
+        delete:
+        - $ref: '#/components/x-stackQL-resources/add-on-attachment/methods/Delete'
+        exec:
+        - $ref: '#/components/x-stackQL-resources/add-on-attachment/methods/Resolution'
+    add-on-config:
+      id: heroku.addons.add-on-config
+      name: add-on-config
+      title: Add On Config
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1config/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1config/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/add-on-config/methods/List'
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/add-on-config/methods/Update'
+        delete: []
+        exec: []
+    add-on-service:
+      id: heroku.addons.add-on-service
+      name: add-on-service
+      title: Add On Service
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1addon-services~1{add_on_service_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1addon-services/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/add-on-service/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/add-on-service/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    add-on:
+      id: heroku.addons.add-on
+      name: add-on
+      title: Add On
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1addons/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Info:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Create:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1addons/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        ListByApp:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1addons/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1addons~1{add_on_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        InfoByApp:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1addons~1{add_on_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1addons~1{add_on_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByUser:
+          operation:
+            $ref: '#/paths/~1users~1{account_identity}~1addons/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1addons/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Resolution:
+          operation:
+            $ref: '#/paths/~1actions~1addons~1resolve/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/add-on/methods/List'
+        - $ref: '#/components/x-stackQL-resources/add-on/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/add-on/methods/ListByApp'
+        - $ref: '#/components/x-stackQL-resources/add-on/methods/InfoByApp'
+        - $ref: '#/components/x-stackQL-resources/add-on/methods/ListByUser'
+        - $ref: '#/components/x-stackQL-resources/add-on/methods/ListByTeam'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/add-on/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/add-on/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/add-on/methods/Delete'
+        exec:
+        - $ref: '#/components/x-stackQL-resources/add-on/methods/Resolution'
+    allowed-add-on-service:
+      id: heroku.addons.allowed-add-on-service
+      name: allowed-add-on-service
+      title: Allowed Add On Service
+      methods:
+        ListByTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1allowed-addon-services/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        CreateByTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1allowed-addon-services/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        DeleteByTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1allowed-addon-services~1{allowed_add_on_service_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/allowed-add-on-service/methods/ListByTeam'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/allowed-add-on-service/methods/CreateByTeam'
+        update: []
+        delete:
+        - $ref: '#/components/x-stackQL-resources/allowed-add-on-service/methods/DeleteByTeam'
+        exec: []
+    plan:
+      id: heroku.addons.plan
+      name: plan
+      title: Plan
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1plans~1{plan_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        InfoByAddOn:
+          operation:
+            $ref: '#/paths/~1addon-services~1{add_on_service_identity}~1plans~1{plan_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByAddOn:
+          operation:
+            $ref: '#/paths/~1addon-services~1{add_on_service_identity}~1plans/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/plan/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/plan/methods/InfoByAddOn'
+        - $ref: '#/components/x-stackQL-resources/plan/methods/ListByAddOn'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/apps.yaml
+++ b/provider/heroku/v0/services/apps.yaml
@@ -1,0 +1,1987 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Apps
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /apps/{app_identity}/features/{app_feature_identity}:
+    get:
+      summary: Info
+      description: Info for an existing app feature.
+      operationId: app_featureInfo
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: app_feature_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-feature.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app-feature'
+      x-stackQL-resource: app-feature
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update an existing app feature.
+      operationId: app_featureUpdate
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: app_feature_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-feature.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app-feature'
+      x-stackQL-resource: app-feature
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                enabled:
+                  $ref: '#/components/schemas/enabled'
+              required:
+              - enabled
+              type:
+              - object
+  /apps/{app_identity}/features:
+    get:
+      summary: List
+      description: List existing app features.
+      operationId: app_featureList
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/app-feature'
+                type:
+                - array
+      x-stackQL-resource: app-feature
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /app-setups:
+    post:
+      summary: Create
+      description: Create a new app setup from a gzipped tar archive containing an app.json manifest file.
+      operationId: app_setupCreate
+      tags:
+      - apps
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app-setup'
+      x-stackQL-resource: app-setup
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+              - source_blob
+              type:
+              - object
+              properties:
+                app:
+                  description: optional parameters for created app
+                  properties:
+                    locked:
+                      $ref: '#/components/schemas/locked'
+                    name:
+                      $ref: '#/components/schemas/name'
+                    organization:
+                      $ref: '#/components/schemas/name'
+                    personal:
+                      $ref: '#/components/schemas/personal'
+                    region:
+                      $ref: '#/components/schemas/name'
+                    space:
+                      $ref: '#/components/schemas/name'
+                    stack:
+                      $ref: '#/components/schemas/name'
+                  type:
+                  - object
+                source_blob:
+                  description: gzipped tarball of source code containing app.json manifest file
+                  properties:
+                    checksum:
+                      description: an optional checksum of the gzipped tarball for verifying its integrity
+                      example: SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+                      readOnly: true
+                      type:
+                      - 'null'
+                      - string
+                    url:
+                      description: URL of gzipped tarball of source code containing app.json manifest file
+                      example: https://example.com/source.tgz?token=xyz
+                      readOnly: true
+                      type:
+                      - string
+                    version:
+                      description: Version of the gzipped tarball.
+                      example: v1.3.0
+                      readOnly: true
+                      type:
+                      - string
+                      - 'null'
+                  type:
+                  - object
+                overrides:
+                  $ref: '#/components/schemas/overrides'
+  /app-setups/{app_setup_identity}:
+    get:
+      summary: Info
+      description: Get the status of an app setup.
+      operationId: app_setupInfo
+      tags:
+      - apps
+      parameters:
+      - name: app_setup_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-setup.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app-setup'
+      x-stackQL-resource: app-setup
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /account/app-transfers:
+    post:
+      summary: Create
+      description: Create a new app transfer.
+      operationId: app_transferCreate
+      tags:
+      - apps
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app-transfer'
+      x-stackQL-resource: app-transfer
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                app:
+                  $ref: '#/components/schemas/identity'
+                recipient:
+                  $ref: '#/components/schemas/identity'
+                silent:
+                  $ref: '#/components/schemas/silent'
+              required:
+              - app
+              - recipient
+              type:
+              - object
+    get:
+      summary: List
+      description: List existing apps transfers.
+      operationId: app_transferList
+      tags:
+      - apps
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/app-transfer'
+                type:
+                - array
+      x-stackQL-resource: app-transfer
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /account/app-transfers/{app_transfer_identity}:
+    delete:
+      summary: Delete
+      description: Delete an existing app transfer
+      operationId: app_transferDelete
+      tags:
+      - apps
+      parameters:
+      - name: app_transfer_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-transfer.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: app-transfer
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Info for existing app transfer.
+      operationId: app_transferInfo
+      tags:
+      - apps
+      parameters:
+      - name: app_transfer_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-transfer.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app-transfer'
+      x-stackQL-resource: app-transfer
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update an existing app transfer.
+      operationId: app_transferUpdate
+      tags:
+      - apps
+      parameters:
+      - name: app_transfer_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-transfer.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app-transfer'
+      x-stackQL-resource: app-transfer
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                state:
+                  $ref: '#/components/schemas/state'
+              required:
+              - state
+              type:
+              - object
+  /apps/{app_identity}/webhook-deliveries/{app_webhook_delivery_identity}:
+    get:
+      summary: Info
+      description: Returns the info for an existing delivery.
+      operationId: app_webhook_deliveryInfo
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: app_webhook_delivery_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-webhook-delivery.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app-webhook-delivery'
+      x-stackQL-resource: app-webhook-delivery
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /apps/{app_identity}/webhook-deliveries:
+    get:
+      summary: List
+      description: Lists existing deliveries for an app.
+      operationId: app_webhook_deliveryList
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/app-webhook-delivery'
+                type:
+                - array
+      x-stackQL-resource: app-webhook-delivery
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /apps/{app_identity}/webhook-events/{app_webhook_event_identity}:
+    get:
+      summary: Info
+      description: Returns the info for a specified webhook event.
+      operationId: app_webhook_eventInfo
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: app_webhook_event_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-webhook-event.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app-webhook-event'
+      x-stackQL-resource: app-webhook-event
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /apps/{app_identity}/webhook-events:
+    get:
+      summary: List
+      description: Lists existing webhook events for an app.
+      operationId: app_webhook_eventList
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/app-webhook-event'
+                type:
+                - array
+      x-stackQL-resource: app-webhook-event
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /apps/{app_identity}/webhooks:
+    post:
+      summary: Create
+      description: Create an app webhook subscription.
+      operationId: app_webhookCreate
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app_webhook'
+      x-stackQL-resource: app-webhook
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                authorization:
+                  $ref: '#/components/schemas/authorization'
+                include:
+                  $ref: '#/components/schemas/include'
+                level:
+                  $ref: '#/components/schemas/level'
+                secret:
+                  $ref: '#/components/schemas/secret'
+                url:
+                  $ref: '#/components/schemas/url'
+              additionalProperties: false
+              required:
+              - include
+              - level
+              - url
+              type:
+              - object
+    get:
+      summary: List
+      description: List all webhook subscriptions for a particular app.
+      operationId: app_webhookList
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/app_webhook'
+                type:
+                - array
+      x-stackQL-resource: app-webhook
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /apps/{app_identity}/webhooks/{app_webhook_identity}:
+    delete:
+      summary: Delete
+      description: Removes an app webhook subscription.
+      operationId: app_webhookDelete
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: app_webhook_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-webhook.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: app-webhook
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Returns the info for an app webhook subscription.
+      operationId: app_webhookInfo
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: app_webhook_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-webhook.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app_webhook'
+      x-stackQL-resource: app-webhook
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Updates the details of an app webhook subscription.
+      operationId: app_webhookUpdate
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: app_webhook_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-webhook.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app_webhook'
+      x-stackQL-resource: app-webhook
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                authorization:
+                  $ref: '#/components/schemas/authorization'
+                include:
+                  $ref: '#/components/schemas/include'
+                level:
+                  $ref: '#/components/schemas/level'
+                secret:
+                  $ref: '#/components/schemas/secret'
+                url:
+                  $ref: '#/components/schemas/url'
+              strictProperties: false
+              type:
+              - object
+  /apps:
+    post:
+      summary: Create
+      description: Create a new app.
+      operationId: appCreate
+      tags:
+      - apps
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app'
+      x-stackQL-resource: app
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+                region:
+                  $ref: '#/components/schemas/identity'
+                stack:
+                  $ref: '#/components/schemas/identity'
+                feature_flags:
+                  description: unique name of app feature
+                  type:
+                  - array
+                  items:
+                    $ref: '#/components/schemas/name'
+              type:
+              - object
+    get:
+      summary: List
+      description: List existing apps.
+      operationId: appList
+      tags:
+      - apps
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/app'
+                type:
+                - array
+      x-stackQL-resource: app
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /apps/{app_identity}:
+    delete:
+      summary: Delete
+      description: Delete an existing app.
+      operationId: appDelete
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: app
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Info for existing app.
+      operationId: appInfo
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app'
+      x-stackQL-resource: app
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update an existing app.
+      operationId: appUpdate
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app'
+      x-stackQL-resource: app
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                build_stack:
+                  $ref: '#/components/schemas/identity'
+                maintenance:
+                  $ref: '#/components/schemas/maintenance'
+                name:
+                  $ref: '#/components/schemas/name'
+              type:
+              - object
+  /users/{account_identity}/apps:
+    get:
+      summary: List Owned and Collaborated
+      description: List owned and collaborated apps (excludes team apps).
+      operationId: appListOwnedAndCollaborated
+      tags:
+      - apps
+      parameters:
+      - name: account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/app'
+                type:
+                - array
+      x-stackQL-resource: app
+      x-stackQL-method: ListOwnedAndCollaborated
+      x-stackQL-verb: select
+  /apps/{app_identity}/acm:
+    post:
+      summary: Enable ACM
+      description: Enable ACM flag for an app
+      operationId: appEnableAcm
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app'
+      x-stackQL-resource: app
+      x-stackQL-method: EnableAcm
+      x-stackQL-verb: update
+    delete:
+      summary: Disable ACM
+      description: Disable ACM flag for an app
+      operationId: appDisableAcm
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: app
+      x-stackQL-method: DisableAcm
+      x-stackQL-verb: delete
+    patch:
+      summary: Refresh ACM
+      description: Refresh ACM for an app
+      operationId: appRefreshAcm
+      tags:
+      - apps
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app'
+      x-stackQL-resource: app
+      x-stackQL-method: RefreshAcm
+      x-stackQL-verb: update
+  /teams/apps:
+    post:
+      summary: Create
+      description: Create a new app in the specified team, in the default team if unspecified, or in personal account, if
+        default team is not set.
+      operationId: team_appCreate
+      tags:
+      - apps
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-app'
+      x-stackQL-resource: team-app
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                locked:
+                  $ref: '#/components/schemas/locked'
+                name:
+                  $ref: '#/components/schemas/name'
+                team:
+                  $ref: '#/components/schemas/name'
+                personal:
+                  $ref: '#/components/schemas/personal'
+                region:
+                  $ref: '#/components/schemas/name'
+                space:
+                  $ref: '#/components/schemas/name'
+                stack:
+                  $ref: '#/components/schemas/name'
+                internal_routing:
+                  $ref: '#/components/schemas/internal_routing'
+              type:
+              - object
+  /teams/apps/{team_app_identity}:
+    get:
+      summary: Info
+      description: Info for a team app.
+      operationId: team_appInfo
+      tags:
+      - apps
+      parameters:
+      - name: team_app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-app'
+      x-stackQL-resource: team-app
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Transfer to Team
+      description: Transfer an existing team app to another team.
+      operationId: team_appTransferToTeam
+      tags:
+      - apps
+      parameters:
+      - name: team_app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-app'
+      x-stackQL-resource: team-app
+      x-stackQL-method: TransferToTeam
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                owner:
+                  $ref: '#/components/schemas/name'
+              required:
+              - owner
+              type:
+              - object
+  /teams/{team_identity}/apps:
+    get:
+      summary: List By Team
+      description: List team apps.
+      operationId: team_appListByTeam
+      tags:
+      - apps
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team-app'
+                type:
+                - array
+      x-stackQL-resource: team-app
+      x-stackQL-method: ListByTeam
+      x-stackQL-verb: select
+components:
+  schemas:
+    app-feature:
+      description: An app feature represents a Heroku labs capability that can be enabled or disabled for an app on Heroku.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        description:
+          $ref: '#/components/schemas/description'
+        doc_url:
+          $ref: '#/components/schemas/doc_url'
+        enabled:
+          $ref: '#/components/schemas/enabled'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        state:
+          $ref: '#/components/schemas/state'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        display_name:
+          $ref: '#/components/schemas/display_name'
+        feedback_email:
+          $ref: '#/components/schemas/feedback_email'
+    created_at:
+      description: when app feature was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    description:
+      description: description of app feature
+      readOnly: true
+      type:
+      - string
+    doc_url:
+      description: documentation URL of app feature
+      readOnly: true
+      type:
+      - string
+    enabled:
+      description: whether or not app feature has been enabled
+      readOnly: false
+      type:
+      - boolean
+    id:
+      description: unique identifier of app feature
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    name:
+      description: unique name of app feature
+      readOnly: true
+      type:
+      - string
+    state:
+      description: state of app feature
+      readOnly: true
+      type:
+      - string
+    updated_at:
+      description: when app feature was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    display_name:
+      description: user readable feature name
+      readOnly: true
+      type:
+      - string
+    feedback_email:
+      description: e-mail to send feedback about the feature
+      readOnly: true
+      type:
+      - string
+    app-setup:
+      description: An app setup represents an app on Heroku that is setup using an environment, addons, and scripts described
+        in an app.json manifest file.
+      type:
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        status:
+          $ref: '#/components/schemas/status'
+        failure_message:
+          $ref: '#/components/schemas/failure_message'
+        app:
+          description: identity of app
+          type:
+          - object
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+        build:
+          description: identity and status of build
+          type:
+          - 'null'
+          - object
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            status:
+              $ref: '#/components/schemas/status'
+            output_stream_url:
+              $ref: '#/components/schemas/output_stream_url'
+        manifest_errors:
+          $ref: '#/components/schemas/manifest_errors'
+        postdeploy:
+          $ref: '#/components/schemas/postdeploy'
+        resolved_success_url:
+          $ref: '#/components/schemas/resolved_success_url'
+    status:
+      description: the overall status of app setup
+      enum:
+      - failed
+      - pending
+      - succeeded
+      readOnly: true
+      type:
+      - string
+    failure_message:
+      description: reason that app setup has failed
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    output_stream_url:
+      description: Build process output will be available from this URL as a stream. The stream is available as either `text/plain`
+        or `text/event-stream`. Clients should be prepared to handle disconnects and can resume the stream by sending a `Range`
+        header (for `text/plain`) or a `Last-Event-Id` header (for `text/event-stream`).
+      readOnly: true
+      type:
+      - string
+    manifest_errors:
+      description: errors associated with invalid app.json manifest file
+      readOnly: true
+      items:
+        type:
+        - string
+      type:
+      - array
+    postdeploy:
+      description: result of postdeploy script
+      type:
+      - object
+      - 'null'
+      properties:
+        output:
+          description: output of the postdeploy script
+          readOnly: true
+          type:
+          - string
+        exit_code:
+          description: The exit code of the postdeploy script
+          readOnly: true
+          type:
+          - integer
+      readOnly: true
+    resolved_success_url:
+      description: fully qualified success url
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    locked:
+      default: false
+      description: are other team members forbidden from joining this app.
+      type:
+      - boolean
+    personal:
+      default: false
+      description: force creation of the app in the user account even if a default team is set.
+      type:
+      - boolean
+    overrides:
+      description: overrides of keys in the app.json manifest file
+      properties:
+        buildpacks:
+          description: overrides the buildpacks specified in the app.json manifest file
+          items:
+            $ref: '#/components/schemas/buildpack_override'
+          type:
+          - array
+        env:
+          description: overrides of the env specified in the app.json manifest file
+          readOnly: true
+          additionalProperties: false
+          patternProperties:
+            ^\w+$:
+              type:
+              - string
+          type:
+          - object
+      type:
+      - object
+    buildpack_override:
+      description: a buildpack override
+      properties:
+        url:
+          description: location of the buildpack
+          type:
+          - string
+      type:
+      - object
+    app-transfer:
+      description: An app transfer represents a two party interaction for transferring ownership of an app.
+      type:
+      - object
+      properties:
+        app:
+          description: app involved in the transfer
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        owner:
+          description: identity of the owner of the transfer
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        recipient:
+          description: identity of the recipient of the transfer
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        state:
+          $ref: '#/components/schemas/state'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    email:
+      description: unique email address of account
+      format: email
+      readOnly: false
+      type:
+      - string
+    identity:
+      anyOf:
+      - $ref: '#/components/schemas/id'
+      - $ref: '#/components/schemas/name'
+    silent:
+      default: false
+      description: whether to suppress email notification when transferring apps
+      readOnly: true
+      type:
+      - boolean
+    app-webhook-delivery:
+      description: Represents the delivery of a webhook notification, including its current status.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        event:
+          description: identity of event
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            include:
+              $ref: '#/components/schemas/include'
+          type:
+          - object
+        id:
+          $ref: '#/components/schemas/id'
+        num_attempts:
+          $ref: '#/components/schemas/num_attempts'
+        next_attempt_at:
+          $ref: '#/components/schemas/next_attempt_at'
+        last_attempt:
+          description: last attempt of a delivery
+          properties:
+            id:
+              $ref: '#/components/schemas/attempt_id'
+            code:
+              $ref: '#/components/schemas/attempt_code'
+            error_class:
+              $ref: '#/components/schemas/attempt_error_class'
+            status:
+              $ref: '#/components/schemas/attempt_status'
+            created_at:
+              $ref: '#/components/schemas/attempt_created_at'
+            updated_at:
+              $ref: '#/components/schemas/attempt_updated_at'
+          type:
+          - object
+          - 'null'
+        status:
+          $ref: '#/components/schemas/status'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        webhook:
+          description: identity of webhook
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            level:
+              $ref: '#/components/schemas/level'
+          type:
+          - object
+    app-webhook-event:
+      description: Represents a webhook event that occurred.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        include:
+          $ref: '#/components/schemas/include'
+        payload:
+          $ref: '#/components/schemas/payload'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    app_webhook:
+      properties:
+        app:
+          description: identity of app. Only used for customer webhooks.
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        include:
+          $ref: '#/components/schemas/include'
+        level:
+          $ref: '#/components/schemas/level'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        url:
+          $ref: '#/components/schemas/url'
+      description: app webhook
+      type:
+      - object
+    include:
+      description: the entities that the subscription provides notifications for
+      items:
+        type:
+        - string
+      type:
+      - array
+    level:
+      description: if `notify`, Heroku makes a single, fire-and-forget delivery attempt. If `sync`, Heroku attempts multiple
+        deliveries until the request is successful or a limit is reached
+      enum:
+      - notify
+      - sync
+      type:
+      - string
+    url:
+      description: the URL where the webhook's notification requests are sent
+      format: uri
+      type:
+      - string
+    authorization:
+      description: a custom `Authorization` header that Heroku will include with all webhook notifications
+      type:
+      - 'null'
+      - string
+    secret:
+      description: "a value that Heroku will use to sign all webhook notification requests (the signature is included in the\
+        \ request\xE2\u20AC\u2122s `Heroku-Webhook-Hmac-SHA256` header)"
+      type:
+      - 'null'
+      - string
+    app:
+      description: An app represents the program that you would like to deploy and run on Heroku.
+      type:
+      - object
+      properties:
+        acm:
+          $ref: '#/components/schemas/acm'
+        archived_at:
+          $ref: '#/components/schemas/archived_at'
+        buildpack_provided_description:
+          $ref: '#/components/schemas/buildpack_provided_description'
+        build_stack:
+          description: identity of the stack that will be used for new builds
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        generation:
+          $ref: '#/components/schemas/generation'
+        git_url:
+          $ref: '#/components/schemas/git_url'
+        id:
+          $ref: '#/components/schemas/id'
+        internal_routing:
+          $ref: '#/components/schemas/internal_routing'
+        maintenance:
+          $ref: '#/components/schemas/maintenance'
+        name:
+          $ref: '#/components/schemas/name'
+        owner:
+          description: identity of app owner
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        organization:
+          description: identity of team
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - 'null'
+          - object
+        team:
+          description: identity of team
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - 'null'
+          - object
+        region:
+          description: identity of app region
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        released_at:
+          $ref: '#/components/schemas/released_at'
+        repo_size:
+          $ref: '#/components/schemas/repo_size'
+        slug_size:
+          $ref: '#/components/schemas/slug_size'
+        space:
+          description: identity of space
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+            shield:
+              $ref: '#/components/schemas/shield'
+          type:
+          - 'null'
+          - object
+        stack:
+          description: identity of app stack
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        web_url:
+          $ref: '#/components/schemas/web_url'
+    acm:
+      description: ACM status of this app
+      default: false
+      readOnly: true
+      type:
+      - boolean
+    archived_at:
+      description: when app was archived
+      format: date-time
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    buildpack_provided_description:
+      description: description from buildpack of app
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    generation:
+      description: Generation of the Heroku platform for this app
+      readOnly: true
+      type:
+      - object
+      properties:
+        id:
+          description: unique identifier of the generation of the Heroku platform for this app
+          format: uuid
+          readOnly: true
+          type:
+          - string
+        name:
+          description: unique name of the generation of the Heroku platform for this app
+          readOnly: true
+          type:
+          - string
+    git_url:
+      description: git repo URL of app
+      pattern: ^https://git\.heroku\.com/[a-z][a-z0-9-]{2,29}\.git$
+      readOnly: true
+      type:
+      - string
+    internal_routing:
+      default: false
+      description: describes whether a Private Spaces app is externally routable or not
+      readOnly: false
+      type:
+      - boolean
+      - 'null'
+    maintenance:
+      default: false
+      description: maintenance status of app
+      readOnly: false
+      type:
+      - boolean
+    released_at:
+      default: null
+      description: when app was released
+      format: date-time
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    repo_size:
+      default: null
+      description: git repo size in bytes of app
+      readOnly: true
+      type:
+      - integer
+      - 'null'
+    slug_size:
+      default: null
+      description: slug size in bytes of app
+      readOnly: true
+      type:
+      - integer
+      - 'null'
+    shield:
+      description: true if this space has shield enabled
+      readOnly: true
+      type:
+      - boolean
+    web_url:
+      description: web URL of app
+      format: uri
+      pattern: ^https?://[a-z][a-z0-9-]{3,43}\.herokuapp\.com/$
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    team-app:
+      description: A team app encapsulates the team specific functionality of Heroku apps.
+      type:
+      - object
+      properties:
+        archived_at:
+          $ref: '#/components/schemas/archived_at'
+        buildpack_provided_description:
+          $ref: '#/components/schemas/buildpack_provided_description'
+        build_stack:
+          description: identity of the stack that will be used for new builds
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        git_url:
+          $ref: '#/components/schemas/git_url'
+        id:
+          $ref: '#/components/schemas/id'
+        internal_routing:
+          $ref: '#/components/schemas/internal_routing'
+        joined:
+          $ref: '#/components/schemas/joined'
+        locked:
+          $ref: '#/components/schemas/locked'
+        maintenance:
+          $ref: '#/components/schemas/maintenance'
+        name:
+          $ref: '#/components/schemas/name'
+        team:
+          description: team that owns this app
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - 'null'
+          - object
+        owner:
+          description: identity of app owner
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - 'null'
+          - object
+        region:
+          description: identity of app region
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        released_at:
+          $ref: '#/components/schemas/released_at'
+        repo_size:
+          $ref: '#/components/schemas/repo_size'
+        slug_size:
+          $ref: '#/components/schemas/slug_size'
+        space:
+          description: identity of space
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - 'null'
+          - object
+        stack:
+          description: identity of app stack
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        web_url:
+          $ref: '#/components/schemas/web_url'
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    app-feature:
+      id: heroku.apps.app-feature
+      name: app-feature
+      title: App Feature
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1features~1{app_feature_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1features~1{app_feature_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1features/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/app-feature/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/app-feature/methods/List'
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/app-feature/methods/Update'
+        delete: []
+        exec: []
+    app-setup:
+      id: heroku.apps.app-setup
+      name: app-setup
+      title: App Setup
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1app-setups/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        Info:
+          operation:
+            $ref: '#/paths/~1app-setups~1{app_setup_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/app-setup/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/app-setup/methods/Create'
+        update: []
+        delete: []
+        exec: []
+    app-transfer:
+      id: heroku.apps.app-transfer
+      name: app-transfer
+      title: App Transfer
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1account~1app-transfers/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1account~1app-transfers/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1account~1app-transfers~1{app_transfer_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1account~1app-transfers~1{app_transfer_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1account~1app-transfers~1{app_transfer_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/app-transfer/methods/List'
+        - $ref: '#/components/x-stackQL-resources/app-transfer/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/app-transfer/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/app-transfer/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/app-transfer/methods/Delete'
+        exec: []
+    app-webhook-delivery:
+      id: heroku.apps.app-webhook-delivery
+      name: app-webhook-delivery
+      title: App Webhook Delivery
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1webhook-deliveries~1{app_webhook_delivery_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1webhook-deliveries/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/app-webhook-delivery/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/app-webhook-delivery/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    app-webhook-event:
+      id: heroku.apps.app-webhook-event
+      name: app-webhook-event
+      title: App Webhook Event
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1webhook-events~1{app_webhook_event_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1webhook-events/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/app-webhook-event/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/app-webhook-event/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    app-webhook:
+      id: heroku.apps.app-webhook
+      name: app-webhook
+      title: App Webhook
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1webhooks/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1webhooks/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1webhooks~1{app_webhook_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1webhooks~1{app_webhook_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1webhooks~1{app_webhook_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/app-webhook/methods/List'
+        - $ref: '#/components/x-stackQL-resources/app-webhook/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/app-webhook/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/app-webhook/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/app-webhook/methods/Delete'
+        exec: []
+    app:
+      id: heroku.apps.app
+      name: app
+      title: App
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1apps/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1apps/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListOwnedAndCollaborated:
+          operation:
+            $ref: '#/paths/~1users~1{account_identity}~1apps/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        EnableAcm:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1acm/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        DisableAcm:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1acm/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        RefreshAcm:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1acm/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/app/methods/List'
+        - $ref: '#/components/x-stackQL-resources/app/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/app/methods/ListOwnedAndCollaborated'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/app/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/app/methods/Update'
+        - $ref: '#/components/x-stackQL-resources/app/methods/EnableAcm'
+        - $ref: '#/components/x-stackQL-resources/app/methods/RefreshAcm'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/app/methods/Delete'
+        - $ref: '#/components/x-stackQL-resources/app/methods/DisableAcm'
+        exec: []
+    team-app:
+      id: heroku.apps.team-app
+      name: team-app
+      title: Team App
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1teams~1apps/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        Info:
+          operation:
+            $ref: '#/paths/~1teams~1apps~1{team_app_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        TransferToTeam:
+          operation:
+            $ref: '#/paths/~1teams~1apps~1{team_app_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1apps/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-app/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/team-app/methods/ListByTeam'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/team-app/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/team-app/methods/TransferToTeam'
+        delete: []
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/builds.yaml
+++ b/provider/heroku/v0/services/builds.yaml
@@ -1,0 +1,496 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Builds
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /apps/{app_identity}/builds:
+    post:
+      summary: Create
+      description: Create a new build.
+      operationId: buildCreate
+      tags:
+      - builds
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/build'
+      x-stackQL-resource: build
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type:
+              - object
+              properties:
+                buildpacks:
+                  $ref: '#/components/schemas/buildpacks'
+                source_blob:
+                  $ref: '#/components/schemas/source_blob'
+              required:
+              - source_blob
+    get:
+      summary: List
+      description: List existing build.
+      operationId: buildList
+      tags:
+      - builds
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/build'
+                type:
+                - array
+      x-stackQL-resource: build
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /apps/{app_identity}/builds/{build_identity}:
+    get:
+      summary: Info
+      description: Info for existing build.
+      operationId: buildInfo
+      tags:
+      - builds
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: build_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of build.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/build'
+      x-stackQL-resource: build
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    delete:
+      summary: Cancel
+      description: Cancel running build.
+      operationId: buildCancel
+      tags:
+      - builds
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: build_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of build.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: build
+      x-stackQL-method: Cancel
+      x-stackQL-verb: select
+  /apps/{app_identity}/build-cache:
+    delete:
+      summary: Delete cache
+      description: Destroy a build cache.
+      operationId: buildDeleteCache
+      tags:
+      - builds
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: build
+      x-stackQL-method: DeleteCache
+      x-stackQL-verb: exec
+  /apps/{app_identity}/buildpack-installations:
+    put:
+      summary: Update
+      description: Update an app's buildpack installations.
+      operationId: buildpack_installationUpdate
+      tags:
+      - builds
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/buildpack-installation'
+                type:
+                - array
+      x-stackQL-resource: buildpack-installation
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                updates:
+                  description: The buildpack attribute can accept a name, a url, or a urn.
+                  items:
+                    $ref: '#/components/schemas/update'
+                  type:
+                  - array
+              required:
+              - updates
+              type:
+              - object
+    get:
+      summary: List
+      description: List an app's existing buildpack installations.
+      operationId: buildpack_installationList
+      tags:
+      - builds
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/buildpack-installation'
+                type:
+                - array
+      x-stackQL-resource: buildpack-installation
+      x-stackQL-method: List
+      x-stackQL-verb: select
+components:
+  schemas:
+    build:
+      description: A build represents the process of transforming a code tarball into build artifacts
+      required:
+      - created_at
+      - id
+      - source_blob
+      - status
+      - updated_at
+      - user
+      type:
+      - object
+      properties:
+        app:
+          description: app that the build belongs to
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        buildpacks:
+          $ref: '#/components/schemas/buildpacks'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        output_stream_url:
+          $ref: '#/components/schemas/output_stream_url'
+        source_blob:
+          $ref: '#/components/schemas/source_blob'
+        release:
+          $ref: '#/components/schemas/release'
+        slug:
+          description: slug created by this build (only applicable for Cedar-generation apps)
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+          - 'null'
+        stack:
+          $ref: '#/components/schemas/stack'
+        status:
+          $ref: '#/components/schemas/status'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        user:
+          description: user that started the build
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            email:
+              $ref: '#/components/schemas/email'
+          type:
+          - object
+    id:
+      description: unique identifier of app
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    buildpacks:
+      description: buildpacks executed for this build, in order (only applicable to Cedar-generation apps)
+      type:
+      - array
+      - 'null'
+      items:
+        description: Buildpack to execute in a build
+        type:
+        - object
+        properties:
+          url:
+            description: the URL of the buildpack for the app
+            readOnly: false
+            type:
+            - string
+          name:
+            description: Buildpack Registry name of the buildpack for the app
+            readOnly: false
+            type:
+            - string
+    created_at:
+      description: when build was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    output_stream_url:
+      description: Build process output will be available from this URL as a stream. The stream is available as either `text/plain`
+        or `text/event-stream`. Clients should be prepared to handle disconnects and can resume the stream by sending a `Range`
+        header (for `text/plain`) or a `Last-Event-Id` header (for `text/event-stream`).
+      readOnly: true
+      type:
+      - string
+    source_blob:
+      description: location of gzipped tarball of source code used to create build
+      properties:
+        checksum:
+          description: an optional checksum of the gzipped tarball for verifying its integrity
+          readOnly: true
+          type:
+          - 'null'
+          - string
+        url:
+          description: URL where gzipped tar archive of source code for build was downloaded.
+          readOnly: true
+          type:
+          - string
+        version:
+          description: Version of the gzipped tarball.
+          readOnly: true
+          type:
+          - string
+          - 'null'
+        version_description:
+          description: Version description of the gzipped tarball.
+          readOnly: true
+          type:
+          - string
+          - 'null'
+      type:
+      - object
+    release:
+      description: release resulting from the build
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+      readOnly: true
+      type:
+      - 'null'
+      - object
+    stack:
+      description: stack of build
+      readOnly: true
+      type:
+      - string
+    status:
+      description: status of build
+      enum:
+      - failed
+      - pending
+      - succeeded
+      readOnly: true
+      type:
+      - string
+    updated_at:
+      description: when build was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    email:
+      description: unique email address of account
+      format: email
+      readOnly: false
+      type:
+      - string
+    buildpack-installation:
+      description: A buildpack installation represents a buildpack that will be run against an app.
+      type:
+      - object
+      properties:
+        ordinal:
+          $ref: '#/components/schemas/ordinal'
+        buildpack:
+          description: buildpack
+          properties:
+            url:
+              $ref: '#/components/schemas/url'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+    ordinal:
+      description: determines the order in which the buildpacks will execute
+      readOnly: true
+      type:
+      - integer
+    url:
+      description: location of the buildpack for the app. Either a url (unofficial buildpacks) or an internal urn (heroku
+        official buildpacks).
+      readOnly: false
+      type:
+      - string
+    name:
+      description: either the Buildpack Registry name or a URL of the buildpack for the app
+      readOnly: false
+      type:
+      - string
+    update:
+      additionalProperties: false
+      description: Properties to update a buildpack installation
+      properties:
+        buildpack:
+          $ref: '#/components/schemas/url'
+      readOnly: false
+      required:
+      - buildpack
+      type:
+      - object
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    build:
+      id: heroku.builds.build
+      name: build
+      title: Build
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1builds/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1builds/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1builds~1{build_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Cancel:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1builds~1{build_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        DeleteCache:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1build-cache/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/build/methods/List'
+        - $ref: '#/components/x-stackQL-resources/build/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/build/methods/Cancel'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/build/methods/Create'
+        update: []
+        delete: []
+        exec:
+        - $ref: '#/components/x-stackQL-resources/build/methods/DeleteCache'
+    buildpack-installation:
+      id: heroku.builds.buildpack-installation
+      name: buildpack-installation
+      title: Buildpack Installation
+      methods:
+        Update:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1buildpack-installations/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1buildpack-installations/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/buildpack-installation/methods/List'
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/buildpack-installation/methods/Update'
+        delete: []
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/collaborators.yaml
+++ b/provider/heroku/v0/services/collaborators.yaml
@@ -1,0 +1,553 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Collaborators
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /apps/{app_identity}/collaborators:
+    post:
+      summary: Create
+      description: Create a new collaborator.
+      operationId: collaboratorCreate
+      tags:
+      - collaborators
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/collaborator'
+      x-stackQL-resource: collaborator
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                silent:
+                  $ref: '#/components/schemas/silent'
+                user:
+                  $ref: '#/components/schemas/identity'
+              required:
+              - user
+              type:
+              - object
+    get:
+      summary: List
+      description: List existing collaborators.
+      operationId: collaboratorList
+      tags:
+      - collaborators
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/collaborator'
+                type:
+                - array
+      x-stackQL-resource: collaborator
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /apps/{app_identity}/collaborators/{collaborator_identity}:
+    delete:
+      summary: Delete
+      description: Delete an existing collaborator.
+      operationId: collaboratorDelete
+      tags:
+      - collaborators
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: collaborator_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of collaborator.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: collaborator
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Info for existing collaborator.
+      operationId: collaboratorInfo
+      tags:
+      - collaborators
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: collaborator_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of collaborator.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/collaborator'
+      x-stackQL-resource: collaborator
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /teams/apps/{app_identity}/collaborators:
+    post:
+      summary: Create
+      description: Create a new collaborator on a team app. Use this endpoint instead of the `/apps/{app_id_or_name}/collaborator`
+        endpoint when you want the collaborator to be granted [permissions] (https://devcenter.heroku.com/articles/org-users-access#roles-and-permissions)
+        according to their role in the team.
+      operationId: team_app_collaboratorCreate
+      tags:
+      - collaborators
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-app-collaborator'
+      x-stackQL-resource: team-app-collaborator
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                permissions:
+                  type:
+                  - array
+                  items:
+                    $ref: '#/components/schemas/name'
+                  description: An array of permissions to give to the collaborator.
+                silent:
+                  $ref: '#/components/schemas/silent'
+                user:
+                  $ref: '#/components/schemas/identity'
+              required:
+              - user
+              type:
+              - object
+  /teams/apps/{team_app_identity}/collaborators/{team_app_collaborator_identity}:
+    delete:
+      summary: Delete
+      description: Delete an existing collaborator from a team app.
+      operationId: team_app_collaboratorDelete
+      tags:
+      - collaborators
+      parameters:
+      - name: team_app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-app.
+      - name: team_app_collaborator_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-app-collaborator.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: team-app-collaborator
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Info for a collaborator on a team app.
+      operationId: team_app_collaboratorInfo
+      tags:
+      - collaborators
+      parameters:
+      - name: team_app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-app.
+      - name: team_app_collaborator_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-app-collaborator.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-app-collaborator'
+      x-stackQL-resource: team-app-collaborator
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update an existing collaborator from a team app.
+      operationId: team_app_collaboratorUpdate
+      tags:
+      - collaborators
+      parameters:
+      - name: team_app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-app.
+      - name: team_app_collaborator_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-app-collaborator.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-app-collaborator'
+      x-stackQL-resource: team-app-collaborator
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                permissions:
+                  type:
+                  - array
+                  items:
+                    $ref: '#/components/schemas/name'
+                  description: An array of permissions to give to the collaborator.
+              required:
+              - permissions
+              type:
+              - object
+  /teams/apps/{team_app_identity}/collaborators:
+    get:
+      summary: List
+      description: List collaborators on a team app.
+      operationId: team_app_collaboratorList
+      tags:
+      - collaborators
+      parameters:
+      - name: team_app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team-app-collaborator'
+                type:
+                - array
+      x-stackQL-resource: team-app-collaborator
+      x-stackQL-method: List
+      x-stackQL-verb: select
+components:
+  schemas:
+    collaborator:
+      description: A collaborator represents an account that has been given access to an app on Heroku.
+      additionalProperties: false
+      required:
+      - app
+      - created_at
+      - id
+      - updated_at
+      - user
+      type:
+      - object
+      properties:
+        app:
+          description: app collaborator belongs to
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        permissions:
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/team-app-permission'
+        role:
+          $ref: '#/components/schemas/role'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        user:
+          description: identity of collaborated account
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            federated:
+              $ref: '#/components/schemas/federated'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+    name:
+      description: unique name of app
+      pattern: ^[a-z][a-z0-9-]{1,28}[a-z0-9]$
+      readOnly: false
+      type:
+      - string
+    id:
+      description: unique identifier of app
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    created_at:
+      description: when collaborator was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    team-app-permission:
+      description: A team app permission is a behavior that is assigned to a user in a team app.
+      type:
+      - object
+      properties:
+        name:
+          $ref: '#/components/schemas/name'
+        description:
+          $ref: '#/components/schemas/description'
+    role:
+      description: role in the team
+      enum:
+      - admin
+      - collaborator
+      - member
+      - owner
+      - null
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    updated_at:
+      description: when collaborator was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    email:
+      description: unique email address of account
+      format: email
+      readOnly: false
+      type:
+      - string
+    federated:
+      description: whether the user is federated and belongs to an Identity Provider
+      readOnly: true
+      type:
+      - boolean
+    silent:
+      default: false
+      description: whether to suppress email invitation when creating collaborator
+      readOnly: false
+      type:
+      - boolean
+    identity:
+      anyOf:
+      - $ref: '#/components/schemas/email'
+      - $ref: '#/components/schemas/id'
+      - $ref: '#/components/schemas/self'
+    self:
+      description: Implicit reference to currently authorized user
+      enum:
+      - '~'
+      readOnly: true
+      type:
+      - string
+    team-app-collaborator:
+      description: A team collaborator represents an account that has been given access to a team app on Heroku.
+      type:
+      - object
+      properties:
+        app:
+          description: app collaborator belongs to
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        permissions:
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/team-app-permission'
+          description: array of permissions for the collaborator (only applicable if the app is on a team)
+        role:
+          $ref: '#/components/schemas/role'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        user:
+          description: identity of collaborated account
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            federated:
+              $ref: '#/components/schemas/federated'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    collaborator:
+      id: heroku.collaborators.collaborator
+      name: collaborator
+      title: Collaborator
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1collaborators/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1collaborators/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1collaborators~1{collaborator_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1collaborators~1{collaborator_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/collaborator/methods/List'
+        - $ref: '#/components/x-stackQL-resources/collaborator/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/collaborator/methods/Create'
+        update: []
+        delete:
+        - $ref: '#/components/x-stackQL-resources/collaborator/methods/Delete'
+        exec: []
+    team-app-collaborator:
+      id: heroku.collaborators.team-app-collaborator
+      name: team-app-collaborator
+      title: Team App Collaborator
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1teams~1apps~1{app_identity}~1collaborators/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        Delete:
+          operation:
+            $ref: '#/paths/~1teams~1apps~1{team_app_identity}~1collaborators~1{team_app_collaborator_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1teams~1apps~1{team_app_identity}~1collaborators~1{team_app_collaborator_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1teams~1apps~1{team_app_identity}~1collaborators~1{team_app_collaborator_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1teams~1apps~1{team_app_identity}~1collaborators/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-app-collaborator/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/team-app-collaborator/methods/List'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/team-app-collaborator/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/team-app-collaborator/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/team-app-collaborator/methods/Delete'
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/config_vars.yaml
+++ b/provider/heroku/v0/services/config_vars.yaml
@@ -1,0 +1,155 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Config Vars
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /apps/{app_identity}/config-vars:
+    get:
+      summary: Info for App
+      description: Get config-vars for app.
+      operationId: config_varInfoForApp
+      tags:
+      - config_vars
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/config_vars'
+      x-stackQL-resource: config-var
+      x-stackQL-method: InfoForApp
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update config-vars for app. You can update existing config-vars by setting them again, and remove by setting
+        it to `null`.
+      operationId: config_varUpdate
+      tags:
+      - config_vars
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/config_vars'
+      x-stackQL-resource: config-var
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              description: "hash of config changes \xE2\u20AC\u201C update values or delete by seting it to `null`"
+              example:
+                FOO: bar
+                BAZ: qux
+              patternProperties:
+                ^\w+$:
+                  type:
+                  - string
+                  - 'null'
+              type:
+              - object
+  /apps/{app_identity}/releases/{release_identity}/config-vars:
+    get:
+      summary: Info for App Release
+      description: Get config-vars for a release.
+      operationId: config_varInfoForAppRelease
+      tags:
+      - config_vars
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: release_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of release.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/config_vars'
+      x-stackQL-resource: config-var
+      x-stackQL-method: InfoForAppRelease
+      x-stackQL-verb: select
+components:
+  schemas:
+    config_vars:
+      additionalProperties: false
+      description: hash of config vars
+      patternProperties:
+        ^\w+$:
+          type:
+          - string
+          - 'null'
+      type:
+      - object
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    config-var:
+      id: heroku.config_vars.config-var
+      name: config-var
+      title: Config Var
+      methods:
+        InfoForApp:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1config-vars/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1config-vars/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        InfoForAppRelease:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1releases~1{release_identity}~1config-vars/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/config-var/methods/InfoForApp'
+        - $ref: '#/components/x-stackQL-resources/config-var/methods/InfoForAppRelease'
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/config-var/methods/Update'
+        delete: []
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/domains.yaml
+++ b/provider/heroku/v0/services/domains.yaml
@@ -1,0 +1,651 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Domains
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /apps/{app_identity}/domains:
+    post:
+      summary: Create
+      description: Create a new domain.
+      operationId: domainCreate
+      tags:
+      - domains
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/domain'
+      x-stackQL-resource: domain
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                hostname:
+                  $ref: '#/components/schemas/hostname'
+                sni_endpoint:
+                  $ref: '#/components/schemas/sni_endpoint'
+              required:
+              - hostname
+              - sni_endpoint
+              type:
+              - object
+    get:
+      summary: List
+      description: List existing domains.
+      operationId: domainList
+      tags:
+      - domains
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/domain'
+                type:
+                - array
+      x-stackQL-resource: domain
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /apps/{app_identity}/domains/{domain_identity}:
+    patch:
+      summary: Update
+      description: Associate an SNI endpoint
+      operationId: domainUpdate
+      tags:
+      - domains
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: domain_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of domain.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/domain'
+      x-stackQL-resource: domain
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                sni_endpoint:
+                  $ref: '#/components/schemas/sni_endpoint'
+              required:
+              - sni_endpoint
+              type:
+              - object
+    delete:
+      summary: Delete
+      description: Delete an existing domain
+      operationId: domainDelete
+      tags:
+      - domains
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: domain_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of domain.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: domain
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Info for existing domain.
+      operationId: domainInfo
+      tags:
+      - domains
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: domain_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of domain.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/domain'
+      x-stackQL-resource: domain
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /apps/{app_identity}/sni-endpoints:
+    post:
+      summary: Create
+      description: Create a new SNI endpoint.
+      operationId: sni_endpointCreate
+      tags:
+      - domains
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sni-endpoint'
+      x-stackQL-resource: sni-endpoint
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                certificate_chain:
+                  $ref: '#/components/schemas/certificate_chain'
+                private_key:
+                  $ref: '#/components/schemas/private_key'
+              required:
+              - certificate_chain
+              - private_key
+              type:
+              - object
+    get:
+      summary: List
+      description: List existing SNI endpoints.
+      operationId: sni_endpointList
+      tags:
+      - domains
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/sni-endpoint'
+                type:
+                - array
+      x-stackQL-resource: sni-endpoint
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /apps/{app_identity}/sni-endpoints/{sni_endpoint_identity}:
+    delete:
+      summary: Delete
+      description: Delete existing SNI endpoint.
+      operationId: sni_endpointDelete
+      tags:
+      - domains
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: sni_endpoint_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of sni-endpoint.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: sni-endpoint
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Info for existing SNI endpoint.
+      operationId: sni_endpointInfo
+      tags:
+      - domains
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: sni_endpoint_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of sni-endpoint.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sni-endpoint'
+      x-stackQL-resource: sni-endpoint
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update an existing SNI endpoint.
+      operationId: sni_endpointUpdate
+      tags:
+      - domains
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: sni_endpoint_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of sni-endpoint.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sni-endpoint'
+      x-stackQL-resource: sni-endpoint
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                certificate_chain:
+                  $ref: '#/components/schemas/certificate_chain'
+                private_key:
+                  $ref: '#/components/schemas/private_key'
+              required:
+              - certificate_chain
+              - private_key
+              type:
+              - object
+components:
+  schemas:
+    domain:
+      description: Domains define what web routes should be routed to an app on Heroku.
+      type:
+      - object
+      properties:
+        acm_status:
+          $ref: '#/components/schemas/acm_status'
+        acm_status_reason:
+          $ref: '#/components/schemas/acm_status_reason'
+        app:
+          description: app that owns the domain
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        cname:
+          $ref: '#/components/schemas/cname'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        hostname:
+          $ref: '#/components/schemas/hostname'
+        id:
+          $ref: '#/components/schemas/id'
+        kind:
+          $ref: '#/components/schemas/kind'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        status:
+          $ref: '#/components/schemas/status'
+        sni_endpoint:
+          description: sni endpoint the domain is associated with
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - 'null'
+          - object
+    acm_status:
+      description: status of this record's ACM
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    acm_status_reason:
+      description: reason for the status of this record's ACM
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    name:
+      description: unique name of app
+      pattern: ^[a-z][a-z0-9-]{1,28}[a-z0-9]$
+      readOnly: false
+      type:
+      - string
+    id:
+      description: unique identifier of app
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    cname:
+      description: canonical name record, the address to point a domain at
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    created_at:
+      description: when domain was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    hostname:
+      description: full hostname
+      format: uri
+      readOnly: true
+      type:
+      - string
+    kind:
+      description: type of domain name
+      enum:
+      - heroku
+      - custom
+      readOnly: true
+      type:
+      - string
+    updated_at:
+      description: when domain was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    status:
+      description: status of this record's cname
+      readOnly: true
+      type:
+      - string
+    sni_endpoint:
+      description: null or unique identifier or name for SNI endpoint
+      type:
+      - 'null'
+      - string
+    sni-endpoint:
+      description: SNI Endpoint is a public address serving a custom SSL cert for HTTPS traffic, using the SNI TLS extension,
+        to a Heroku app.
+      type:
+      - object
+      properties:
+        certificate_chain:
+          $ref: '#/components/schemas/certificate_chain'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        display_name:
+          $ref: '#/components/schemas/display_name'
+        domains:
+          $ref: '#/components/schemas/domains'
+        app:
+          description: application that this SSL certificate is on
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        ssl_cert:
+          description: certificate provided by this endpoint
+          type:
+          - object
+          properties:
+            ca_signed?:
+              $ref: '#/components/schemas/ca_signed?'
+            cert_domains:
+              $ref: '#/components/schemas/cert_domains'
+            expires_at:
+              $ref: '#/components/schemas/expires_at'
+            issuer:
+              $ref: '#/components/schemas/issuer'
+            self_signed?:
+              $ref: '#/components/schemas/self_signed?'
+            starts_at:
+              $ref: '#/components/schemas/starts_at'
+            subject:
+              $ref: '#/components/schemas/subject'
+            id:
+              description: unique identifier of this SSL certificate
+              format: uuid
+              readOnly: true
+              type:
+              - string
+    certificate_chain:
+      description: 'raw contents of the public certificate chain (eg: .crt or .pem file)'
+      readOnly: false
+      type:
+      - string
+    display_name:
+      description: unique name for SSL certificate
+      pattern: ^[a-z][a-z0-9-]{2,29}$
+      readOnly: false
+      type:
+      - string
+      - 'null'
+    domains:
+      description: domains associated with this SSL certificate
+      type:
+      - array
+      readOnly: true
+      items:
+        $ref: '#/components/schemas/id'
+    ca_signed?:
+      readOnly: true
+      type:
+      - boolean
+    cert_domains:
+      readOnly: true
+      type:
+      - array
+    expires_at:
+      readOnly: true
+      format: date-time
+      type:
+      - string
+    issuer:
+      readOnly: true
+      type:
+      - string
+    self_signed?:
+      readOnly: true
+      type:
+      - boolean
+    starts_at:
+      readOnly: true
+      format: date-time
+      type:
+      - string
+    subject:
+      readOnly: true
+      type:
+      - string
+    private_key:
+      description: contents of the private key (eg .key file)
+      readOnly: false
+      type:
+      - string
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    domain:
+      id: heroku.domains.domain
+      name: domain
+      title: Domain
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1domains/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1domains/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1domains~1{domain_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1domains~1{domain_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1domains~1{domain_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/domain/methods/List'
+        - $ref: '#/components/x-stackQL-resources/domain/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/domain/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/domain/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/domain/methods/Delete'
+        exec: []
+    sni-endpoint:
+      id: heroku.domains.sni-endpoint
+      name: sni-endpoint
+      title: Sni Endpoint
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1sni-endpoints/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1sni-endpoints/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1sni-endpoints~1{sni_endpoint_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1sni-endpoints~1{sni_endpoint_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1sni-endpoints~1{sni_endpoint_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/sni-endpoint/methods/List'
+        - $ref: '#/components/x-stackQL-resources/sni-endpoint/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/sni-endpoint/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/sni-endpoint/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/sni-endpoint/methods/Delete'
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/dynos.yaml
+++ b/provider/heroku/v0/services/dynos.yaml
@@ -1,0 +1,889 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Dynos
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /dyno-sizes/{dyno_size_identity}:
+    get:
+      summary: Info
+      description: Info for existing dyno size.
+      operationId: dyno_sizeInfo
+      tags:
+      - dynos
+      parameters:
+      - name: dyno_size_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of dyno-size.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/dyno-size'
+      x-stackQL-resource: dyno-size
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /dyno-sizes:
+    get:
+      summary: List
+      description: List existing dyno sizes.
+      operationId: dyno_sizeList
+      tags:
+      - dynos
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/dyno-size'
+                type:
+                - array
+      x-stackQL-resource: dyno-size
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /apps/{app_identity}/available-dyno-sizes:
+    get:
+      summary: List App Dyno Sizes
+      description: List available dyno sizes for an app
+      operationId: dyno_sizeListAppDynoSizes
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/dyno-size'
+      x-stackQL-resource: dyno-size
+      x-stackQL-method: ListAppDynoSizes
+      x-stackQL-verb: exec
+  /apps/{app_identity}/dynos:
+    post:
+      summary: Create
+      description: Create a new dyno.
+      operationId: dynoCreate
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/dyno'
+      x-stackQL-resource: dyno
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                attach:
+                  $ref: '#/components/schemas/attach'
+                command:
+                  $ref: '#/components/schemas/command'
+                env:
+                  $ref: '#/components/schemas/env'
+                force_no_tty:
+                  $ref: '#/components/schemas/force_no_tty'
+                size:
+                  $ref: '#/components/schemas/size'
+                type:
+                  $ref: '#/components/schemas/type'
+                time_to_live:
+                  $ref: '#/components/schemas/time_to_live'
+              required:
+              - command
+              type:
+              - object
+    delete:
+      summary: Restart all
+      description: Restart all dynos.
+      operationId: dynoRestartAll
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: dyno
+      x-stackQL-method: RestartAll
+      x-stackQL-verb: exec
+    get:
+      summary: List
+      description: List existing dynos.
+      operationId: dynoList
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/dyno'
+                type:
+                - array
+      x-stackQL-resource: dyno
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /apps/{app_identity}/dynos/{dyno_identity}:
+    delete:
+      summary: Restart
+      description: Restart dyno.
+      operationId: dynoRestart
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: dyno_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of dyno.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: dyno
+      x-stackQL-method: Restart
+      x-stackQL-verb: exec
+    get:
+      summary: Info
+      description: Info for existing dyno.
+      operationId: dynoInfo
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: dyno_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of dyno.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/dyno'
+      x-stackQL-resource: dyno
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /apps/{app_identity}/formations/{dyno_formation_type}:
+    delete:
+      summary: Restart formation
+      description: Restart dynos of a given formation type.
+      operationId: dynoRestartFormation
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: dyno_formation_type
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for formation_type of dyno.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: dyno
+      x-stackQL-method: RestartFormation
+      x-stackQL-verb: exec
+  /apps/{app_identity}/dynos/{dyno_identity}/actions/stop:
+    post:
+      summary: Stop
+      description: Stop dyno.
+      operationId: dynoStop
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: dyno_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of dyno.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type:
+                - object
+      x-stackQL-resource: dyno
+      x-stackQL-method: Stop
+      x-stackQL-verb: exec
+  /apps/{app_identity}/formations/{dyno_formation_type}/actions/stop:
+    post:
+      summary: Stop formation
+      description: Stop dynos of a given formation type.
+      operationId: dynoStopFormation
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: dyno_formation_type
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for formation_type of dyno.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type:
+                - object
+      x-stackQL-resource: dyno
+      x-stackQL-method: StopFormation
+      x-stackQL-verb: exec
+  /apps/{app_identity}/formation/{formation_identity}:
+    get:
+      summary: Info
+      description: Info for a process type
+      operationId: formationInfo
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: formation_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of formation.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/formation'
+      x-stackQL-resource: formation
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update process type
+      operationId: formationUpdate
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: formation_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of formation.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/formation'
+      x-stackQL-resource: formation
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                dyno_size:
+                  $ref: '#/components/schemas/dyno_size'
+                quantity:
+                  $ref: '#/components/schemas/quantity'
+              type:
+              - object
+  /apps/{app_identity}/formation:
+    get:
+      summary: List
+      description: List process type formation
+      operationId: formationList
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/formation'
+                type:
+                - array
+      x-stackQL-resource: formation
+      x-stackQL-method: List
+      x-stackQL-verb: select
+    patch:
+      summary: Batch Update
+      description: Batch update process types
+      operationId: formationBatchUpdate
+      tags:
+      - dynos
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/formation'
+                type:
+                - array
+      x-stackQL-resource: formation
+      x-stackQL-method: BatchUpdate
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                updates:
+                  type:
+                  - array
+                  items:
+                    $ref: '#/components/schemas/update'
+                  description: Array with formation updates. Each element must have "type", the id or name of the process
+                    type to be updated, and can optionally update its "quantity" or "dyno_size".
+              required:
+              - updates
+              type:
+              - object
+components:
+  schemas:
+    dyno-size:
+      description: 'Dyno sizes are the values and details of sizes that can be assigned to dynos. This information can also
+        be found at : [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).'
+      type:
+      - object
+      properties:
+        architecture:
+          $ref: '#/components/schemas/architecture'
+        compute:
+          $ref: '#/components/schemas/compute'
+        cost:
+          $ref: '#/components/schemas/cost'
+        dedicated:
+          $ref: '#/components/schemas/dedicated'
+        precise_dyno_units:
+          $ref: '#/components/schemas/precise_dyno_units'
+        generation:
+          $ref: '#/components/schemas/generation'
+        id:
+          $ref: '#/components/schemas/id'
+        memory:
+          $ref: '#/components/schemas/memory'
+        name:
+          $ref: '#/components/schemas/name'
+        private_space_only:
+          $ref: '#/components/schemas/private_space_only'
+    architecture:
+      description: CPU architecture of this dyno size
+      readOnly: true
+      type:
+      - string
+    compute:
+      description: minimum vCPUs, non-dedicated may get more depending on load
+      readOnly: true
+      type:
+      - integer
+    cost:
+      description: price information for this dyno size
+      readOnly: true
+      type:
+      - 'null'
+      - object
+    dedicated:
+      description: whether this dyno will be dedicated to one user
+      readOnly: true
+      type:
+      - boolean
+    precise_dyno_units:
+      description: unit of consumption for Heroku Enterprise customers to 2 decimal places
+      readOnly: true
+      type:
+      - number
+    generation:
+      description: Generation of the Heroku platform for this dyno size
+      readOnly: true
+      type:
+      - object
+      properties:
+        id:
+          description: unique identifier of the generation of the Heroku platform for this dyno size
+          format: uuid
+          readOnly: true
+          type:
+          - string
+        name:
+          description: unique name of the generation of the Heroku platform for this dyno size
+          readOnly: true
+          type:
+          - string
+    id:
+      description: unique identifier of the dyno size
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    memory:
+      description: amount of RAM in GB
+      readOnly: true
+      type:
+      - number
+    name:
+      description: name of the dyno size
+      readOnly: true
+      type:
+      - string
+    private_space_only:
+      description: whether this dyno can only be provisioned in a private space
+      readOnly: true
+      type:
+      - boolean
+    dyno:
+      description: 'Dynos encapsulate running processes of an app on Heroku. Detailed information about dyno sizes can be
+        found at: [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).'
+      type:
+      - object
+      properties:
+        attach_url:
+          $ref: '#/components/schemas/attach_url'
+        command:
+          $ref: '#/components/schemas/command'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        release:
+          description: app release of the dyno
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            version:
+              $ref: '#/components/schemas/version'
+          type:
+          - object
+        app:
+          description: app formation belongs to
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        size:
+          $ref: '#/components/schemas/size'
+        state:
+          $ref: '#/components/schemas/state'
+        type:
+          $ref: '#/components/schemas/type'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    attach_url:
+      description: a URL to stream output from for attached processes or null for non-attached processes
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    command:
+      description: command used to start this process
+      readOnly: false
+      type:
+      - string
+    created_at:
+      description: when dyno was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    version:
+      description: unique version assigned to the release
+      readOnly: true
+      type:
+      - integer
+    size:
+      description: dyno size
+      readOnly: false
+      type:
+      - string
+    state:
+      description: 'current status of process (either: crashed, down, idle, starting, or up)'
+      readOnly: true
+      type:
+      - string
+    type:
+      description: type of process
+      readOnly: false
+      type:
+      - string
+    updated_at:
+      description: when process last changed state
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    attach:
+      description: whether to stream output or not
+      readOnly: false
+      type:
+      - boolean
+    env:
+      additionalProperties: false
+      description: custom environment to add to the dyno config vars
+      patternProperties:
+        ^\w+$:
+          type:
+          - string
+      readOnly: false
+      type:
+      - object
+    force_no_tty:
+      description: force an attached one-off dyno to not run in a tty
+      readOnly: false
+      type:
+      - boolean
+      - 'null'
+    time_to_live:
+      description: seconds until dyno expires, after which it will soon be killed, max 86400 seconds (24 hours)
+      readOnly: false
+      type:
+      - integer
+    formation:
+      description: The formation of processes that should be maintained for an app. Update the formation to scale processes
+        or change dyno sizes. Available process type names and commands are defined by the `process_types` attribute for the
+        [slug](#slug) currently released on an app.
+      type:
+      - object
+      properties:
+        app:
+          description: app formation belongs to
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        command:
+          $ref: '#/components/schemas/command'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        dyno_size:
+          description: dyno size
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        id:
+          $ref: '#/components/schemas/id'
+        quantity:
+          $ref: '#/components/schemas/quantity'
+        size:
+          $ref: '#/components/schemas/size'
+        type:
+          $ref: '#/components/schemas/type'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    quantity:
+      description: number of processes to maintain
+      readOnly: false
+      type:
+      - integer
+    dyno_size:
+      description: dyno size
+      oneOf:
+      - required:
+        - id
+      - required:
+        - name
+      properties:
+        id:
+          description: unique identifier of the dyno size
+          format: uuid
+          readOnly: true
+          type:
+          - string
+        name:
+          description: name of the dyno size
+          readOnly: true
+          type:
+          - string
+      readOnly: false
+      required:
+      - id
+      type:
+      - object
+    update:
+      additionalProperties: false
+      description: Properties to update a process type
+      properties:
+        dyno_size:
+          $ref: '#/components/schemas/dyno_size'
+        quantity:
+          $ref: '#/components/schemas/quantity'
+        type:
+          $ref: '#/components/schemas/type'
+      readOnly: false
+      required:
+      - type
+      type:
+      - object
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    dyno-size:
+      id: heroku.dynos.dyno-size
+      name: dyno-size
+      title: Dyno Size
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1dyno-sizes~1{dyno_size_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1dyno-sizes/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListAppDynoSizes:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1available-dyno-sizes/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/dyno-size/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/dyno-size/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec:
+        - $ref: '#/components/x-stackQL-resources/dyno-size/methods/ListAppDynoSizes'
+    dyno:
+      id: heroku.dynos.dyno
+      name: dyno
+      title: Dyno
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1dynos/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        RestartAll:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1dynos/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1dynos/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Restart:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1dynos~1{dyno_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1dynos~1{dyno_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        RestartFormation:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1formations~1{dyno_formation_type}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Stop:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1dynos~1{dyno_identity}~1actions~1stop/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        StopFormation:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1formations~1{dyno_formation_type}~1actions~1stop/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/dyno/methods/List'
+        - $ref: '#/components/x-stackQL-resources/dyno/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/dyno/methods/Create'
+        update: []
+        delete: []
+        exec:
+        - $ref: '#/components/x-stackQL-resources/dyno/methods/RestartAll'
+        - $ref: '#/components/x-stackQL-resources/dyno/methods/Restart'
+        - $ref: '#/components/x-stackQL-resources/dyno/methods/RestartFormation'
+        - $ref: '#/components/x-stackQL-resources/dyno/methods/Stop'
+        - $ref: '#/components/x-stackQL-resources/dyno/methods/StopFormation'
+    formation:
+      id: heroku.dynos.formation
+      name: formation
+      title: Formation
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1formation~1{formation_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1formation~1{formation_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1formation/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        BatchUpdate:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1formation/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/formation/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/formation/methods/List'
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/formation/methods/Update'
+        - $ref: '#/components/x-stackQL-resources/formation/methods/BatchUpdate'
+        delete: []
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/keys.yaml
+++ b/provider/heroku/v0/services/keys.yaml
@@ -1,0 +1,147 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Keys
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /account/keys/{key_identity}:
+    get:
+      summary: Info
+      description: Info for existing key.
+      operationId: keyInfo
+      tags:
+      - keys
+      parameters:
+      - name: key_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of key.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/key'
+      x-stackQL-resource: key
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /account/keys:
+    get:
+      summary: List
+      description: List existing keys.
+      operationId: keyList
+      tags:
+      - keys
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/key'
+                type:
+                - array
+      x-stackQL-resource: key
+      x-stackQL-method: List
+      x-stackQL-verb: select
+components:
+  schemas:
+    key:
+      description: Keys represent public SSH keys associated with an account and are used to authorize accounts as they are
+        performing git operations.
+      type:
+      - object
+      properties:
+        comment:
+          $ref: '#/components/schemas/comment'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        email:
+          $ref: '#/components/schemas/email'
+        fingerprint:
+          $ref: '#/components/schemas/fingerprint'
+        id:
+          $ref: '#/components/schemas/id'
+        public_key:
+          $ref: '#/components/schemas/public_key'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    comment:
+      description: comment on the key
+      readOnly: true
+      type:
+      - string
+    created_at:
+      description: when key was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    email:
+      deprecated: true
+      description: deprecated. Please refer to 'comment' instead
+      readOnly: true
+      type:
+      - string
+    fingerprint:
+      description: a unique identifying string based on contents
+      readOnly: true
+      type:
+      - string
+    id:
+      description: unique identifier of this key
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    public_key:
+      description: full public_key as uploaded
+      readOnly: true
+      type:
+      - string
+    updated_at:
+      description: when key was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    key:
+      id: heroku.keys.key
+      name: key
+      title: Key
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1account~1keys~1{key_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1account~1keys/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/key/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/key/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/logging.yaml
+++ b/provider/heroku/v0/services/logging.yaml
@@ -1,0 +1,446 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Logging
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /apps/{app_identity}/log-drains:
+    post:
+      summary: Create
+      description: Create a new log drain.
+      operationId: log_drainCreate
+      tags:
+      - logging
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/log-drain'
+      x-stackQL-resource: log-drain
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                url:
+                  $ref: '#/components/schemas/url'
+              required:
+              - url
+              type:
+              - object
+    get:
+      summary: List
+      description: List existing log drains.
+      operationId: log_drainList
+      tags:
+      - logging
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/log-drain'
+                type:
+                - array
+      x-stackQL-resource: log-drain
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /addons/{add_on_identity}/log-drains/{log_drain_query_identity}:
+    put:
+      summary: Update
+      description: Update an add-on owned log drain.
+      operationId: log_drainUpdate
+      tags:
+      - logging
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      - name: log_drain_query_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for query_identity of log-drain.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/log-drain'
+      x-stackQL-resource: log-drain
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                url:
+                  $ref: '#/components/schemas/url'
+              required:
+              - url
+              type:
+              - object
+  /apps/{app_identity}/log-drains/{log_drain_query_identity}:
+    delete:
+      summary: Delete
+      description: Delete an existing log drain. Log drains added by add-ons can only be removed by removing the add-on.
+      operationId: log_drainDelete
+      tags:
+      - logging
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: log_drain_query_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for query_identity of log-drain.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: log-drain
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Info for existing log drain.
+      operationId: log_drainInfo
+      tags:
+      - logging
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: log_drain_query_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for query_identity of log-drain.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/log-drain'
+      x-stackQL-resource: log-drain
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /addons/{add_on_identity}/log-drains:
+    get:
+      summary: List By Add-on
+      description: List existing log drains for an add-on.
+      operationId: log_drainListByAddOn
+      tags:
+      - logging
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/log-drain'
+                type:
+                - array
+      x-stackQL-resource: log-drain
+      x-stackQL-method: ListByAddOn
+      x-stackQL-verb: select
+  /apps/{app_identity}/log-sessions:
+    post:
+      summary: Create
+      description: Create a new log session.
+      operationId: log_sessionCreate
+      tags:
+      - logging
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/log-session'
+      x-stackQL-resource: log-session
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                dyno_name:
+                  $ref: '#/components/schemas/dyno_name'
+                type:
+                  $ref: '#/components/schemas/type'
+                lines:
+                  $ref: '#/components/schemas/lines'
+                source:
+                  $ref: '#/components/schemas/source'
+                tail:
+                  $ref: '#/components/schemas/tail'
+              type:
+              - object
+components:
+  schemas:
+    log-drain:
+      description: '[Log drains](https://devcenter.heroku.com/articles/log-drains) provide a way to forward your Heroku logs
+        to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets
+        from Heroku, whereupon its URL can be added to an app using this API. Some add-ons will add a log drain when they
+        are provisioned to an app. These drains can only be removed by removing the add-on.'
+      type:
+      - object
+      properties:
+        addon:
+          $ref: '#/components/schemas/addon'
+        app:
+          $ref: '#/components/schemas/app'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        token:
+          $ref: '#/components/schemas/token'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        url:
+          $ref: '#/components/schemas/url'
+    addon:
+      description: add-on that created the drain
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        app:
+          description: billing application associated with this add-on
+          type:
+          - object
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+      readOnly: true
+      type:
+      - object
+      - 'null'
+    id:
+      description: unique identifier of add-on
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    name:
+      description: globally unique name of the add-on
+      pattern: ^[a-zA-Z][A-Za-z0-9_-]+$
+      type:
+      - string
+    app:
+      description: application that is attached to this drain
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+      readOnly: true
+      type:
+      - object
+      - 'null'
+    created_at:
+      description: when log drain was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    token:
+      description: token associated with the log drain
+      readOnly: true
+      type:
+      - string
+    updated_at:
+      description: when log drain was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    url:
+      description: url associated with the log drain
+      readOnly: true
+      type:
+      - string
+    log-session:
+      description: A log session is a reference to the http based log stream for an app.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        logplex_url:
+          $ref: '#/components/schemas/logplex_url'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    logplex_url:
+      description: URL for log streaming session
+      readOnly: true
+      type:
+      - string
+    dyno_name:
+      description: dyno name to limit results to
+      readOnly: false
+      type:
+      - string
+    type:
+      description: process type to limit results to
+      readOnly: false
+      type:
+      - string
+    lines:
+      description: number of log lines to stream at once
+      readOnly: false
+      type:
+      - integer
+    source:
+      description: log source to limit results to
+      readOnly: false
+      type:
+      - string
+    tail:
+      description: whether to stream ongoing logs
+      readOnly: false
+      type:
+      - boolean
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    log-drain:
+      id: heroku.logging.log-drain
+      name: log-drain
+      title: Log Drain
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1log-drains/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1log-drains/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1log-drains~1{log_drain_query_identity}/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1log-drains~1{log_drain_query_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1log-drains~1{log_drain_query_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByAddOn:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1log-drains/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/log-drain/methods/List'
+        - $ref: '#/components/x-stackQL-resources/log-drain/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/log-drain/methods/ListByAddOn'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/log-drain/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/log-drain/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/log-drain/methods/Delete'
+        exec: []
+    log-session:
+      id: heroku.logging.log-session
+      name: log-session
+      title: Log Session
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1log-sessions/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+      sqlVerbs:
+        select: []
+        insert:
+        - $ref: '#/components/x-stackQL-resources/log-session/methods/Create'
+        update: []
+        delete: []
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/misc.yaml
+++ b/provider/heroku/v0/services/misc.yaml
@@ -1,0 +1,6939 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Misc
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /account/delinquency:
+    get:
+      summary: Info
+      description: Account delinquency information.
+      operationId: account_delinquencyInfo
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/account-delinquency'
+      x-stackQL-resource: account-delinquency
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /addon-region-capabilities:
+    get:
+      summary: List
+      description: List all existing add-on region capabilities.
+      operationId: add_on_region_capabilityList
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on-region-capability'
+                type:
+                - array
+      x-stackQL-resource: add-on-region-capability
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /addon-services/{add_on_service_identity}/region-capabilities:
+    get:
+      summary: List by Add-on Service
+      description: List existing add-on region capabilities for an add-on-service
+      operationId: add_on_region_capabilityListByAddOnService
+      tags:
+      - misc
+      parameters:
+      - name: add_on_service_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on-service.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on-region-capability'
+                type:
+                - array
+      x-stackQL-resource: add-on-region-capability
+      x-stackQL-method: ListByAddOnService
+      x-stackQL-verb: select
+  /regions/{region_identity}/addon-region-capabilities:
+    get:
+      summary: List By Region
+      description: List existing add-on region capabilities for a region.
+      operationId: add_on_region_capabilityListByRegion
+      tags:
+      - misc
+      parameters:
+      - name: region_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of region.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on-region-capability'
+                type:
+                - array
+      x-stackQL-resource: add-on-region-capability
+      x-stackQL-method: ListByRegion
+      x-stackQL-verb: select
+  /addons/{add_on_identity}/webhook-deliveries/{app_webhook_delivery_identity}:
+    get:
+      summary: Info
+      description: Returns the info for an existing delivery.  Can only be accessed by the add-on partner providing this add-on.
+      operationId: add_on_webhook_deliveryInfo
+      tags:
+      - misc
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      - name: app_webhook_delivery_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-webhook-delivery.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app-webhook-delivery'
+      x-stackQL-resource: add-on-webhook-delivery
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /addons/{add_on_identity}/webhook-deliveries:
+    get:
+      summary: List
+      description: Lists existing deliveries for an add-on.  Can only be accessed by the add-on partner providing this add-on.
+      operationId: add_on_webhook_deliveryList
+      tags:
+      - misc
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/app-webhook-delivery'
+                type:
+                - array
+      x-stackQL-resource: add-on-webhook-delivery
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /addons/{add_on_identity}/webhook-events/{app_webhook_event_identity}:
+    get:
+      summary: Info
+      description: Returns the info for a specified webhook event.  Can only be accessed by the add-on partner providing this
+        add-on.
+      operationId: add_on_webhook_eventInfo
+      tags:
+      - misc
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      - name: app_webhook_event_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-webhook-event.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/app-webhook-event'
+      x-stackQL-resource: add-on-webhook-event
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /addons/{add_on_identity}/webhook-events:
+    get:
+      summary: List
+      description: Lists existing webhook events for an add-on.  Can only be accessed by the add-on partner providing this
+        add-on.
+      operationId: add_on_webhook_eventList
+      tags:
+      - misc
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/app-webhook-event'
+                type:
+                - array
+      x-stackQL-resource: add-on-webhook-event
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /addons/{add_on_identity}/webhooks:
+    post:
+      summary: Create
+      description: Create an add-on webhook subscription.  Can only be accessed by the add-on partner providing this add-on.
+      operationId: add_on_webhookCreate
+      tags:
+      - misc
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addon_webhook'
+      x-stackQL-resource: add-on-webhook
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                authorization:
+                  $ref: '#/components/schemas/authorization'
+                include:
+                  $ref: '#/components/schemas/include'
+                level:
+                  $ref: '#/components/schemas/level'
+                secret:
+                  $ref: '#/components/schemas/secret'
+                url:
+                  $ref: '#/components/schemas/url'
+              additionalProperties: false
+              required:
+              - include
+              - level
+              - url
+              type:
+              - object
+    get:
+      summary: List
+      description: List all webhook subscriptions for a particular add-on.  Can only be accessed by the add-on partner providing
+        this add-on.
+      operationId: add_on_webhookList
+      tags:
+      - misc
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/addon_webhook'
+                type:
+                - array
+      x-stackQL-resource: add-on-webhook
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /addons/{add_on_identity}/webhooks/{app_webhook_identity}:
+    delete:
+      summary: Delete
+      description: Removes an add-on webhook subscription.  Can only be accessed by the add-on partner providing this add-on.
+      operationId: add_on_webhookDelete
+      tags:
+      - misc
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      - name: app_webhook_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-webhook.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: add-on-webhook
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Returns the info for an add-on webhook subscription.  Can only be accessed by the add-on partner providing
+        this add-on.
+      operationId: add_on_webhookInfo
+      tags:
+      - misc
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      - name: app_webhook_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-webhook.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addon_webhook'
+      x-stackQL-resource: add-on-webhook
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Updates the details of an add-on webhook subscription.  Can only be accessed by the add-on partner providing
+        this add-on.
+      operationId: add_on_webhookUpdate
+      tags:
+      - misc
+      parameters:
+      - name: add_on_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of add-on.
+      - name: app_webhook_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app-webhook.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/addon_webhook'
+      x-stackQL-resource: add-on-webhook
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                authorization:
+                  $ref: '#/components/schemas/authorization'
+                include:
+                  $ref: '#/components/schemas/include'
+                level:
+                  $ref: '#/components/schemas/level'
+                secret:
+                  $ref: '#/components/schemas/secret'
+                url:
+                  $ref: '#/components/schemas/url'
+              strictProperties: false
+              type:
+              - object
+  /enterprise-accounts/{enterprise_account_identity}/archives/{archive_year}/{archive_month}:
+    get:
+      summary: Info
+      description: Get archive for a single month.
+      operationId: archiveInfo
+      tags:
+      - misc
+      parameters:
+      - name: enterprise_account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of enterprise-account.
+      - name: archive_year
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for year of archive.
+      - name: archive_month
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for month of archive.
+      responses:
+        '200':
+          description: Successful operation
+      x-stackQL-resource: archive
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /enterprise-accounts/{enterprise_account_identity}/archives:
+    get:
+      summary: List
+      description: List existing archives.
+      operationId: archiveList
+      tags:
+      - misc
+      parameters:
+      - name: enterprise_account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of enterprise-account.
+      responses:
+        '200':
+          description: Successful operation
+      x-stackQL-resource: archive
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /enterprise-accounts/{enterprise_account_identity}/events:
+    get:
+      summary: List
+      description: List existing events. Returns all events for one day, defaulting to current day. Order, actor, action,
+        and type, and day query params can be specified as query parameters. For example, '/enterprise-accounts/:id/events?order=desc&actor=user@example.com&action=create&type=app&day=2020-09-30'
+        would return events in descending order and only return app created events by the user with user@example.com email
+        address.
+      operationId: audit_trail_eventList
+      tags:
+      - misc
+      parameters:
+      - name: enterprise_account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of enterprise-account.
+      responses:
+        '200':
+          description: Successful operation
+      x-stackQL-resource: audit-trail-event
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /account/credits:
+    post:
+      summary: Create
+      description: Create a new credit.
+      operationId: creditCreate
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/credit'
+      x-stackQL-resource: credit
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                code1:
+                  description: first code from a discount card
+                  example: 012abc
+                  type:
+                  - string
+                code2:
+                  description: second code from a discount card
+                  example: 012abc
+                  type:
+                  - string
+              type:
+              - object
+    get:
+      summary: List
+      description: List existing credits.
+      operationId: creditList
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/credit'
+                type:
+                - array
+      x-stackQL-resource: credit
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /account/credits/{credit_identity}:
+    get:
+      summary: Info
+      description: Info for existing credit.
+      operationId: creditInfo
+      tags:
+      - misc
+      parameters:
+      - name: credit_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of credit.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/credit'
+      x-stackQL-resource: credit
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /enterprise-accounts/{enterprise_account_id}/usage/daily:
+    get:
+      summary: Info
+      description: 'Retrieves usage for an enterprise account for a range of days. Start and end dates can be specified as
+        query parameters using the date format YYYY-MM-DD. The enterprise account identifier can be found from the [enterprise
+        account list](https://devcenter.heroku.com/articles/platform-api-reference#enterprise-account-list).
+
+        '
+      operationId: enterprise_account_daily_usageInfo
+      tags:
+      - misc
+      parameters:
+      - name: enterprise_account_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of enterprise-account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/enterprise-account-daily-usage'
+                type:
+                - array
+      x-stackQL-resource: enterprise-account-daily-usage
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                start:
+                  $ref: '#/components/schemas/start_date'
+                end:
+                  $ref: '#/components/schemas/end_date'
+              required:
+              - start
+              type:
+              - object
+  /enterprise-accounts/{enterprise_account_identity}/members:
+    get:
+      summary: List
+      description: List members in an enterprise account.
+      operationId: enterprise_account_memberList
+      tags:
+      - misc
+      parameters:
+      - name: enterprise_account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of enterprise-account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/enterprise-account-member'
+                type:
+                - array
+      x-stackQL-resource: enterprise-account-member
+      x-stackQL-method: List
+      x-stackQL-verb: select
+    post:
+      summary: Create
+      description: Create a member in an enterprise account.
+      operationId: enterprise_account_memberCreate
+      tags:
+      - misc
+      parameters:
+      - name: enterprise_account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of enterprise-account.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/enterprise-account-member'
+      x-stackQL-resource: enterprise-account-member
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                user:
+                  $ref: '#/components/schemas/user_identity'
+                permissions:
+                  $ref: '#/components/schemas/permissions'
+                federated:
+                  description: whether membership is being created as part of SSO JIT
+                  example: false
+                  type:
+                  - boolean
+              required:
+              - user
+              - permissions
+              type:
+              - object
+  /enterprise-accounts/{enterprise_account_identity}/members/{enterprise_account_member_user_identity}:
+    patch:
+      summary: Update
+      description: Update a member in an enterprise account.
+      operationId: enterprise_account_memberUpdate
+      tags:
+      - misc
+      parameters:
+      - name: enterprise_account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of enterprise-account.
+      - name: enterprise_account_member_user_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for user_identity of enterprise-account-member.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/enterprise-account-member'
+      x-stackQL-resource: enterprise-account-member
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                permissions:
+                  $ref: '#/components/schemas/permissions'
+              required:
+              - permissions
+              type:
+              - object
+    delete:
+      summary: Delete
+      description: delete a member in an enterprise account.
+      operationId: enterprise_account_memberDelete
+      tags:
+      - misc
+      parameters:
+      - name: enterprise_account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of enterprise-account.
+      - name: enterprise_account_member_user_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for user_identity of enterprise-account-member.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: enterprise-account-member
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+  /enterprise-accounts/{enterprise_account_id}/usage/monthly:
+    get:
+      summary: Info
+      description: 'Retrieves usage for an enterprise account for a range of months. Start and end dates can be specified
+        as query parameters using the date format YYYY-MM. If no end date is specified, one month of usage is returned. The
+        enterprise account identifier can be found from the [enterprise account list](https://devcenter.heroku.com/articles/platform-api-reference#enterprise-account-list).
+
+        '
+      operationId: enterprise_account_monthly_usageInfo
+      tags:
+      - misc
+      parameters:
+      - name: enterprise_account_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of enterprise-account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/enterprise-account-monthly-usage'
+                type:
+                - array
+      x-stackQL-resource: enterprise-account-monthly-usage
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                start:
+                  $ref: '#/components/schemas/start_date'
+                end:
+                  $ref: '#/components/schemas/end_date'
+              required:
+              - start
+              type:
+              - object
+  /enterprise-accounts:
+    get:
+      summary: List
+      description: List enterprise accounts in which you are a member.
+      operationId: enterprise_accountList
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/enterprise-account'
+                type:
+                - array
+      x-stackQL-resource: enterprise-account
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /enterprise-accounts/{enterprise_account_identity}:
+    get:
+      summary: Info
+      description: Information about an enterprise account.
+      operationId: enterprise_accountInfo
+      tags:
+      - misc
+      parameters:
+      - name: enterprise_account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of enterprise-account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/enterprise-account'
+      x-stackQL-resource: enterprise-account
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update enterprise account properties
+      operationId: enterprise_accountUpdate
+      tags:
+      - misc
+      parameters:
+      - name: enterprise_account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of enterprise-account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/enterprise-account'
+      x-stackQL-resource: enterprise-account
+      x-stackQL-method: Update
+      x-stackQL-verb: exec
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+              type:
+              - object
+  /filters/apps:
+    post:
+      summary: Apps
+      description: Request an apps list filtered by app id.
+      operationId: filter_appsApps
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team-app'
+                type:
+                - array
+      x-stackQL-resource: filter-apps
+      x-stackQL-method: Apps
+      x-stackQL-verb: select
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/filter'
+  /generations/{stack_identity}:
+    get:
+      summary: Info
+      description: Info for generation.
+      operationId: generationInfo
+      tags:
+      - misc
+      parameters:
+      - name: stack_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of stack.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/generation'
+      x-stackQL-resource: generation
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /generations:
+    get:
+      summary: List
+      description: List available generations.
+      operationId: generationList
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/generation'
+                type:
+                - array
+      x-stackQL-resource: generation
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /teams/{team_identity}/available-generations:
+    get:
+      summary: List by Team
+      description: List available generations for a team.
+      operationId: generationListByTeam
+      tags:
+      - misc
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/generation'
+                type:
+                - array
+      x-stackQL-resource: generation
+      x-stackQL-method: ListByTeam
+      x-stackQL-verb: select
+  /teams/{team_name}/identity-providers:
+    get:
+      summary: List By Team
+      description: Get a list of a team's Identity Providers
+      operationId: identity_providerListByTeam
+      tags:
+      - misc
+      parameters:
+      - name: team_name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for name of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/identity-provider'
+                type:
+                - array
+      x-stackQL-resource: identity-provider
+      x-stackQL-method: ListByTeam
+      x-stackQL-verb: select
+    post:
+      summary: Create By Team
+      description: Create an Identity Provider for a team
+      operationId: identity_providerCreateByTeam
+      tags:
+      - misc
+      parameters:
+      - name: team_name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for name of team.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/identity-provider'
+      x-stackQL-resource: identity-provider
+      x-stackQL-method: CreateByTeam
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                certificate:
+                  $ref: '#/components/schemas/certificate'
+                entity_id:
+                  $ref: '#/components/schemas/entity_id'
+                slo_target_url:
+                  $ref: '#/components/schemas/slo_target_url'
+                sso_target_url:
+                  $ref: '#/components/schemas/sso_target_url'
+              required:
+              - certificate
+              - sso_target_url
+              - entity_id
+              type:
+              - object
+  /teams/{team_name}/identity-providers/{identity_provider_id}:
+    patch:
+      summary: Update By Team
+      description: Update a team's Identity Provider
+      operationId: identity_providerUpdateByTeam
+      tags:
+      - misc
+      parameters:
+      - name: team_name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for name of team.
+      - name: identity_provider_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of identity-provider.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/identity-provider'
+      x-stackQL-resource: identity-provider
+      x-stackQL-method: UpdateByTeam
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                certificate:
+                  $ref: '#/components/schemas/certificate'
+                entity_id:
+                  $ref: '#/components/schemas/entity_id'
+                slo_target_url:
+                  $ref: '#/components/schemas/slo_target_url'
+                sso_target_url:
+                  $ref: '#/components/schemas/sso_target_url'
+              type:
+              - object
+    delete:
+      summary: Delete By Team
+      description: Delete a team's Identity Provider
+      operationId: identity_providerDeleteByTeam
+      tags:
+      - misc
+      parameters:
+      - name: team_name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for name of team.
+      - name: identity_provider_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of identity-provider.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: identity-provider
+      x-stackQL-method: DeleteByTeam
+      x-stackQL-verb: delete
+  /spaces/{space_identity}/inbound-ruleset:
+    get:
+      summary: Current
+      description: Current inbound ruleset for a space
+      operationId: inbound_rulesetCurrent
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inbound-ruleset'
+      x-stackQL-resource: inbound-ruleset
+      x-stackQL-method: Current
+      x-stackQL-verb: select
+    put:
+      summary: Create
+      description: Create a new inbound ruleset
+      operationId: inbound_rulesetCreate
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inbound-ruleset'
+      x-stackQL-resource: inbound-ruleset
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type:
+              - object
+              properties:
+                rules:
+                  type:
+                  - array
+                  items:
+                    $ref: '#/components/schemas/rule'
+  /spaces/{space_identity}/inbound-rulesets/{inbound_ruleset_identity}:
+    get:
+      summary: Info
+      description: Info on an existing Inbound Ruleset
+      operationId: inbound_rulesetInfo
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      - name: inbound_ruleset_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of inbound-ruleset.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inbound-ruleset'
+      x-stackQL-resource: inbound-ruleset
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /spaces/{space_identity}/inbound-rulesets:
+    get:
+      summary: List
+      description: List all inbound rulesets for a space
+      operationId: inbound_rulesetList
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/inbound-ruleset'
+                type:
+                - array
+      x-stackQL-resource: inbound-ruleset
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /account/invoice-address:
+    get:
+      summary: info
+      description: Retrieve existing invoice address.
+      operationId: invoice_addressInfo
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/invoice-address'
+      x-stackQL-resource: invoice-address
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    put:
+      summary: update
+      description: Update invoice address for an account.
+      operationId: invoice_addressUpdate
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/invoice-address'
+      x-stackQL-resource: invoice-address
+      x-stackQL-method: Update
+      x-stackQL-verb: select
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                address_1:
+                  $ref: '#/components/schemas/address_1'
+                address_2:
+                  $ref: '#/components/schemas/address_2'
+                city:
+                  $ref: '#/components/schemas/city'
+                country:
+                  $ref: '#/components/schemas/country'
+                other:
+                  $ref: '#/components/schemas/other'
+                postal_code:
+                  $ref: '#/components/schemas/postal_code'
+                state:
+                  $ref: '#/components/schemas/state'
+                use_invoice_address:
+                  $ref: '#/components/schemas/use_invoice_address'
+              type:
+              - object
+  /account/invoices/{invoice_identity}:
+    get:
+      summary: Info
+      description: Info for existing invoice.
+      operationId: invoiceInfo
+      tags:
+      - misc
+      parameters:
+      - name: invoice_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of invoice.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/invoice'
+      x-stackQL-resource: invoice
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /account/invoices:
+    get:
+      summary: List
+      description: List existing invoices.
+      operationId: invoiceList
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/invoice'
+                type:
+                - array
+      x-stackQL-resource: invoice
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /password-resets:
+    post:
+      summary: Reset Password
+      description: Reset account's password. This will send a reset password link to the user's email address.
+      operationId: password_resetResetPassword
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/password-reset'
+      x-stackQL-resource: password-reset
+      x-stackQL-method: ResetPassword
+      x-stackQL-verb: select
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  $ref: '#/components/schemas/email'
+              required:
+              - email
+              type:
+              - object
+  /password-resets/{password_reset_reset_password_token}/actions/finalize:
+    post:
+      summary: Complete Reset Password
+      description: Complete password reset.
+      operationId: password_resetCompleteResetPassword
+      tags:
+      - misc
+      parameters:
+      - name: password_reset_reset_password_token
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for reset_password_token of password-reset.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/password-reset'
+      x-stackQL-resource: password-reset
+      x-stackQL-method: CompleteResetPassword
+      x-stackQL-verb: select
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                password:
+                  $ref: '#/components/schemas/password'
+                password_confirmation:
+                  $ref: '#/components/schemas/password_confirmation'
+              required:
+              - password
+              - password_confirmation
+              type:
+              - object
+  /spaces/{space_identity}/peering-info:
+    get:
+      summary: Info
+      description: Provides the necessary information to establish an AWS VPC Peering with your private space.
+      operationId: peering_infoInfo
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/peering-info'
+      x-stackQL-resource: peering-info
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /teams/{team_identity}/permissions:
+    get:
+      summary: List
+      description: List permission entities for a team.
+      operationId: permission_entityList
+      tags:
+      - misc
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/permission-entity'
+                type:
+                - array
+      x-stackQL-resource: permission-entity
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /pipelines/{pipeline_id}/latest-builds:
+    get:
+      summary: List
+      description: List latest builds for each app in a pipeline
+      operationId: pipeline_buildList
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/pipeline-build'
+                type:
+                - array
+      x-stackQL-resource: pipeline-build
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /pipelines/{pipeline_id}/stage/{pipeline_coupling_stage}/config-vars:
+    get:
+      summary: Info for App
+      description: Get config-vars for a pipeline stage.
+      operationId: pipeline_config_varInfoForApp
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      - name: pipeline_coupling_stage
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for stage of pipeline-coupling.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/config_vars'
+      x-stackQL-resource: pipeline-config-var
+      x-stackQL-method: InfoForApp
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update config-vars for a pipeline stage. You can update existing config-vars by setting them again, and
+        remove by setting it to `null`.
+      operationId: pipeline_config_varUpdate
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      - name: pipeline_coupling_stage
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for stage of pipeline-coupling.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/config_vars'
+      x-stackQL-resource: pipeline-config-var
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              description: "hash of config changes \xE2\u20AC\u201C update values or delete by seting it to `null`"
+              example:
+                FOO: bar
+                BAZ: qux
+              patternProperties:
+                ^[\w\.\:\[\]]+$:
+                  type:
+                  - string
+                  - 'null'
+              type:
+              - object
+  /pipeline-promotions/{pipeline_promotion_id}/promotion-targets:
+    get:
+      summary: List
+      description: List promotion targets belonging to an existing promotion.
+      operationId: pipeline_promotion_targetList
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_promotion_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline-promotion.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/pipeline-promotion-target'
+                type:
+                - array
+      x-stackQL-resource: pipeline-promotion-target
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /pipelines/{pipeline_id}/pipeline-stack:
+    get:
+      summary: Default Stack
+      description: The stack for a given pipeline, used for CI and Review Apps that have no stack defined in app.json.
+      operationId: pipeline_stackDefaultStack
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pipeline-stack'
+      x-stackQL-resource: pipeline-stack
+      x-stackQL-method: DefaultStack
+      x-stackQL-verb: select
+  /pipeline-transfers:
+    post:
+      summary: Create
+      description: Create a new pipeline transfer.
+      operationId: pipeline_transferCreate
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pipeline-transfer'
+      x-stackQL-resource: pipeline-transfer
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                pipeline:
+                  description: The pipeline to transfer
+                  properties:
+                    id:
+                      $ref: '#/components/schemas/id'
+                  type:
+                  - object
+                new_owner:
+                  description: New pipeline owner
+                  properties:
+                    id:
+                      description: unique identifier of a pipeline owner
+                      example: 01234567-89ab-cdef-0123-456789abcdef
+                      format: uuid
+                      type:
+                      - string
+                    type:
+                      description: type of pipeline owner
+                      example: team
+                      pattern: (^team$|^user$)
+                      type:
+                      - string
+                  type:
+                  - object
+              required:
+              - pipeline
+              - new_owner
+              type:
+              - object
+  /account/rate-limits:
+    get:
+      summary: Info
+      description: Info for rate limits.
+      operationId: rate_limitInfo
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/rate-limit'
+      x-stackQL-resource: rate-limit
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /review-apps:
+    post:
+      summary: Create
+      description: Create a new review app
+      operationId: review_appCreate
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/review-app'
+      x-stackQL-resource: review-app
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                branch:
+                  $ref: '#/components/schemas/branch'
+                pr_number:
+                  $ref: '#/components/schemas/pr_number'
+                pipeline:
+                  $ref: '#/components/schemas/id'
+                source_blob:
+                  $ref: '#/components/schemas/source_blob'
+                environment:
+                  $ref: '#/components/schemas/config_vars'
+                  description: A set of key value pairs which will be put into the environment of the spawned review app process.
+                fork_repo_id:
+                  $ref: '#/components/schemas/fork_repo_id'
+              required:
+              - branch
+              - pipeline
+              - source_blob
+              type:
+              - object
+  /review-apps/{review_app_id}:
+    get:
+      summary: Get review app
+      description: Gets an existing review app
+      operationId: review_appGetReviewApp
+      tags:
+      - misc
+      parameters:
+      - name: review_app_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of review-app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/review-app'
+      x-stackQL-resource: review-app
+      x-stackQL-method: GetReviewApp
+      x-stackQL-verb: exec
+    delete:
+      summary: Delete
+      description: Delete an existing review app
+      operationId: review_appDelete
+      tags:
+      - misc
+      parameters:
+      - name: review_app_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of review-app.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: review-app
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+  /apps/{app_identity}/review-app:
+    get:
+      summary: Get review app by app_id
+      description: Get a review app using the associated app_id
+      operationId: review_appGetReviewAppByAppId
+      tags:
+      - misc
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/review-app'
+      x-stackQL-resource: review-app
+      x-stackQL-method: GetReviewAppByAppId
+      x-stackQL-verb: exec
+  /pipelines/{pipeline_id}/review-apps:
+    get:
+      summary: List
+      description: List review apps for a pipeline
+      operationId: review_appList
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/review-app'
+                type:
+                - array
+      x-stackQL-resource: review-app
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /pipelines/{pipeline_id}/review-app-config:
+    post:
+      summary: Enable
+      description: Enable review apps for a pipeline
+      operationId: review_app_configEnable
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/review-app-config'
+      x-stackQL-resource: review-app-config
+      x-stackQL-method: Enable
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                repo:
+                  $ref: '#/components/schemas/repo'
+                  description: The full_name of the repository that you want enable review-apps from.
+                automatic_review_apps:
+                  $ref: '#/components/schemas/automatic_review_apps'
+                  description: If true, this will trigger the creation of review apps when pull-requests are opened in the
+                    repo.
+                destroy_stale_apps:
+                  $ref: '#/components/schemas/destroy_stale_apps'
+                  description: If true, this will trigger automatic deletion of review apps when they're stale
+                stale_days:
+                  $ref: '#/components/schemas/stale_days'
+                  description: If destroy_stale_apps is true, then apps will be destroyed after this many days
+                deploy_target:
+                  $ref: '#/components/schemas/deploy_target'
+                  description: Provides a key/value pair to specify whether to use a common runtime or a private space
+                wait_for_ci:
+                  $ref: '#/components/schemas/wait_for_ci'
+                  description: If true, review apps will only be created when CI passes
+                base_name:
+                  $ref: '#/components/schemas/base_name'
+                  description: A unique prefix that will be used to create review app names
+              required:
+              - repo
+              type:
+              - object
+    get:
+      summary: Info
+      description: Get review apps configuration for a pipeline
+      operationId: review_app_configInfo
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/review-app-config'
+      x-stackQL-resource: review-app-config
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update review app configuration for a pipeline
+      operationId: review_app_configUpdate
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/review-app-config'
+      x-stackQL-resource: review-app-config
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                automatic_review_apps:
+                  $ref: '#/components/schemas/automatic_review_apps'
+                  description: If true, this will trigger the creation of review apps when pull-requests are opened in the
+                    repo
+                destroy_stale_apps:
+                  $ref: '#/components/schemas/destroy_stale_apps'
+                  description: If true, this will trigger automatic deletion of review apps when they're stale
+                stale_days:
+                  $ref: '#/components/schemas/stale_days'
+                  description: If destroy_stale_apps is true, then apps will be destroyed after this many days
+                deploy_target:
+                  $ref: '#/components/schemas/deploy_target'
+                  description: Provides a key/value pair to specify whether to use a common runtime or a private space
+                wait_for_ci:
+                  $ref: '#/components/schemas/wait_for_ci'
+                  description: If true, review apps will only be created when CI passes
+                base_name:
+                  $ref: '#/components/schemas/base_name'
+                  description: A unique prefix that will be used to create review app names
+              type:
+              - object
+    delete:
+      summary: Delete
+      description: Disable review apps for a pipeline
+      operationId: review_app_configDelete
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: review-app-config
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+  /users/{account_identity}/sms-number:
+    get:
+      summary: SMS Number
+      description: Recover an account using an SMS recovery code
+      operationId: sms_numberSmsNumber
+      tags:
+      - misc
+      parameters:
+      - name: account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sms-number'
+      x-stackQL-resource: sms-number
+      x-stackQL-method: SmsNumber
+      x-stackQL-verb: select
+  /users/{account_identity}/sms-number/actions/recover:
+    post:
+      summary: Recover
+      description: Recover an account using an SMS recovery code
+      operationId: sms_numberRecover
+      tags:
+      - misc
+      parameters:
+      - name: account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sms-number'
+      x-stackQL-resource: sms-number
+      x-stackQL-method: Recover
+      x-stackQL-verb: select
+  /users/{account_identity}/sms-number/actions/confirm:
+    post:
+      summary: Confirm
+      description: Confirm an SMS number change with a confirmation code
+      operationId: sms_numberConfirm
+      tags:
+      - misc
+      parameters:
+      - name: account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sms-number'
+      x-stackQL-resource: sms-number
+      x-stackQL-method: Confirm
+      x-stackQL-verb: select
+  /sources:
+    post:
+      summary: Create
+      description: Create URLs for uploading and downloading source.
+      operationId: sourceCreate
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/source'
+      x-stackQL-resource: source
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+  /apps/{app_identity}/sources:
+    post:
+      summary: Create - Deprecated
+      description: Create URLs for uploading and downloading source. Deprecated in favor of `POST /sources`
+      operationId: sourceCreateDeprecated
+      tags:
+      - misc
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/source'
+      x-stackQL-resource: source
+      x-stackQL-method: CreateDeprecated
+      x-stackQL-verb: insert
+  /spaces/{space_identity}/members/{account_identity}:
+    get:
+      summary: Info
+      description: List permissions for a given user on a given space.
+      operationId: space_app_accessInfo
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      - name: account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/space-app-access'
+      x-stackQL-resource: space-app-access
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update an existing user's set of permissions on a space.
+      operationId: space_app_accessUpdate
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      - name: account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/space-app-access'
+      x-stackQL-resource: space-app-access
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type:
+              - object
+              required:
+              - permissions
+              properties:
+                permissions:
+                  type:
+                  - array
+                  items:
+                    type:
+                    - object
+                    properties:
+                      name:
+                        type:
+                        - string
+  /spaces/{space_identity}/members:
+    get:
+      summary: List
+      description: List all users and their permissions on a space.
+      operationId: space_app_accessList
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/space-app-access'
+                type:
+                - array
+      x-stackQL-resource: space-app-access
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /spaces/{space_identity}/nat:
+    get:
+      summary: Info
+      description: Current state of network address translation for a space.
+      operationId: space_natInfo
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/space-nat'
+      x-stackQL-resource: space-nat
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /spaces/{space_identity}/topology:
+    get:
+      summary: Topology
+      description: Current space topology
+      operationId: space_topologyTopology
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/space-topology'
+      x-stackQL-resource: space-topology
+      x-stackQL-method: Topology
+      x-stackQL-verb: select
+  /spaces/{space_identity}/transfer:
+    post:
+      summary: transfer
+      description: Transfer space between enterprise teams
+      operationId: space_transferTransfer
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/space'
+      x-stackQL-resource: space-transfer
+      x-stackQL-method: Transfer
+      x-stackQL-verb: exec
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                new_owner:
+                  $ref: '#/components/schemas/name'
+              required:
+              - new_owner
+              type:
+              - object
+  /teams/{team_identity}/addons:
+    get:
+      summary: List For Team
+      description: List add-ons used across all Team apps
+      operationId: team_add_onListForTeam
+      tags:
+      - misc
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/add-on'
+                type:
+                - array
+      x-stackQL-resource: team-add-on
+      x-stackQL-method: ListForTeam
+      x-stackQL-verb: select
+  /teams/permissions:
+    get:
+      summary: List
+      description: Lists permissions available to teams.
+      operationId: team_app_permissionList
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team-app-permission'
+                type:
+                - array
+      x-stackQL-resource: team-app-permission
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /teams/{team_id}/usage/daily:
+    get:
+      summary: Info
+      description: 'Retrieves usage for an enterprise team for a range of days. Start and end dates can be specified as query
+        parameters using the date format YYYY-MM-DD. The team identifier can be found from the [team list endpoint](https://devcenter.heroku.com/articles/platform-api-reference#team-list).
+
+        '
+      operationId: team_daily_usageInfo
+      tags:
+      - misc
+      parameters:
+      - name: team_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team-daily-usage'
+                type:
+                - array
+      x-stackQL-resource: team-daily-usage
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                start:
+                  $ref: '#/components/schemas/start_date'
+                end:
+                  $ref: '#/components/schemas/end_date'
+              required:
+              - start
+              type:
+              - object
+  /teams/{team_identity}/delinquency:
+    get:
+      summary: Info
+      description: Team delinquency information.
+      operationId: team_delinquencyInfo
+      tags:
+      - misc
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-delinquency'
+      x-stackQL-resource: team-delinquency
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /teams/{team_identity}/invoices/{team_invoice_identity}:
+    get:
+      summary: Info
+      description: Info for existing invoice.
+      operationId: team_invoiceInfo
+      tags:
+      - misc
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      - name: team_invoice_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-invoice.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-invoice'
+      x-stackQL-resource: team-invoice
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /teams/{team_identity}/invoices:
+    get:
+      summary: List
+      description: List existing invoices.
+      operationId: team_invoiceList
+      tags:
+      - misc
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team-invoice'
+                type:
+                - array
+      x-stackQL-resource: team-invoice
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /teams/{team_id}/usage/monthly:
+    get:
+      summary: Info
+      description: 'Retrieves usage for an enterprise team for a range of months. Start and end dates can be specified as
+        query parameters using the date, YYYY-MM. If no end date is specified, one month of usage is returned. The team identifier
+        can be found from the [team list endpoint](https://devcenter.heroku.com/articles/platform-api-reference#team-list).
+
+        '
+      operationId: team_monthly_usageInfo
+      tags:
+      - misc
+      parameters:
+      - name: team_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team-monthly-usage'
+                type:
+                - array
+      x-stackQL-resource: team-monthly-usage
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                start:
+                  $ref: '#/components/schemas/start_date'
+                end:
+                  $ref: '#/components/schemas/end_date'
+              required:
+              - start
+              type:
+              - object
+  /teams/{team_preferences_identity}/preferences:
+    get:
+      summary: List
+      description: Retrieve Team Preferences
+      operationId: team_preferencesList
+      tags:
+      - misc
+      parameters:
+      - name: team_preferences_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-preferences.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-preferences'
+      x-stackQL-resource: team-preferences
+      x-stackQL-method: List
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update Team Preferences
+      operationId: team_preferencesUpdate
+      tags:
+      - misc
+      parameters:
+      - name: team_preferences_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-preferences.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-preferences'
+      x-stackQL-resource: team-preferences
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type:
+              - object
+              properties:
+                addons-controls:
+                  $ref: '#/components/schemas/addons-controls'
+  /teams/{team_identity}/spaces:
+    get:
+      summary: List
+      description: List spaces owned by the team
+      operationId: team_spaceList
+      tags:
+      - misc
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/space'
+                type:
+                - array
+      x-stackQL-resource: team-space
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /telemetry-drains:
+    post:
+      summary: Create
+      description: Create a telemetry drain.
+      operationId: telemetry_drainCreate
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/telemetry-drain'
+      x-stackQL-resource: telemetry-drain
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              properties:
+                owner:
+                  $ref: '#/components/schemas/owner'
+                signals:
+                  $ref: '#/components/schemas/signals'
+                exporter:
+                  $ref: '#/components/schemas/exporter'
+              required:
+              - owner
+              - signals
+              - exporter
+              type:
+              - object
+  /apps/{app_identity}/telemetry-drains:
+    get:
+      summary: List by App
+      description: List telemetry drains for an app.
+      operationId: telemetry_drainListByApp
+      tags:
+      - misc
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/telemetry-drain'
+                type:
+                - array
+      x-stackQL-resource: telemetry-drain
+      x-stackQL-method: ListByApp
+      x-stackQL-verb: select
+  /spaces/{space_identity}/telemetry-drains:
+    get:
+      summary: List by Space
+      description: List telemetry drains for a space.
+      operationId: telemetry_drainListBySpace
+      tags:
+      - misc
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/telemetry-drain'
+                type:
+                - array
+      x-stackQL-resource: telemetry-drain
+      x-stackQL-method: ListBySpace
+      x-stackQL-verb: select
+  /telemetry-drains/{telemetry_drain_identity}:
+    patch:
+      summary: Update
+      description: Update a telemetry drain.
+      operationId: telemetry_drainUpdate
+      tags:
+      - misc
+      parameters:
+      - name: telemetry_drain_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of telemetry-drain.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/telemetry-drain'
+      x-stackQL-resource: telemetry-drain
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              properties:
+                signals:
+                  $ref: '#/components/schemas/signals'
+                exporter:
+                  $ref: '#/components/schemas/exporter'
+              type:
+              - object
+    delete:
+      summary: Delete
+      description: Delete a telemetry drain.
+      operationId: telemetry_drainDelete
+      tags:
+      - misc
+      parameters:
+      - name: telemetry_drain_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of telemetry-drain.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: telemetry-drain
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Info for a telemetry drain.
+      operationId: telemetry_drainInfo
+      tags:
+      - misc
+      parameters:
+      - name: telemetry_drain_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of telemetry-drain.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/telemetry-drain'
+      x-stackQL-resource: telemetry-drain
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /test-runs/{test_run_id}/test-cases:
+    get:
+      summary: List
+      description: List test cases
+      operationId: test_caseList
+      tags:
+      - misc
+      parameters:
+      - name: test_run_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of test-run.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/test-case'
+      x-stackQL-resource: test-case
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /test-runs/{test_run_identity}/test-nodes:
+    get:
+      summary: List
+      description: List test nodes
+      operationId: test_nodeList
+      tags:
+      - misc
+      parameters:
+      - name: test_run_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of test-run.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/test-node'
+      x-stackQL-resource: test-node
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /test-runs:
+    post:
+      summary: Create
+      description: Create a new test-run.
+      operationId: test_runCreate
+      tags:
+      - misc
+      parameters: []
+      responses:
+        '201':
+          description: Created
+      x-stackQL-resource: test-run
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                commit_branch:
+                  $ref: '#/components/schemas/commit_branch'
+                commit_message:
+                  $ref: '#/components/schemas/commit_message'
+                commit_sha:
+                  $ref: '#/components/schemas/commit_sha'
+                debug:
+                  $ref: '#/components/schemas/debug'
+                organization:
+                  $ref: '#/components/schemas/identity'
+                pipeline:
+                  $ref: '#/components/schemas/identity'
+                source_blob_url:
+                  $ref: '#/components/schemas/source_blob_url'
+              required:
+              - commit_branch
+              - commit_message
+              - commit_sha
+              - pipeline
+              - source_blob_url
+              type:
+              - object
+  /test-runs/{test_run_id}:
+    get:
+      summary: Info
+      description: Info for existing test-run.
+      operationId: test_runInfo
+      tags:
+      - misc
+      parameters:
+      - name: test_run_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of test-run.
+      responses:
+        '200':
+          description: Successful operation
+      x-stackQL-resource: test-run
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /pipelines/{pipeline_id}/test-runs:
+    get:
+      summary: List
+      description: List existing test-runs for a pipeline.
+      operationId: test_runList
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/test-run'
+      x-stackQL-resource: test-run
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /pipelines/{pipeline_id}/test-runs/{test_run_number}:
+    get:
+      summary: Info By Pipeline
+      description: Info for existing test-run by Pipeline
+      operationId: test_runInfoByPipeline
+      tags:
+      - misc
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      - name: test_run_number
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for number of test-run.
+      responses:
+        '200':
+          description: Successful operation
+      x-stackQL-resource: test-run
+      x-stackQL-method: InfoByPipeline
+      x-stackQL-verb: select
+  /test-runs/{test_run_number}:
+    patch:
+      summary: Update
+      description: Update a test-run's status.
+      operationId: test_runUpdate
+      tags:
+      - misc
+      parameters:
+      - name: test_run_number
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for number of test-run.
+      responses:
+        '200':
+          description: Successful operation
+      x-stackQL-resource: test-run
+      x-stackQL-method: Update
+      x-stackQL-verb: select
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                status:
+                  $ref: '#/components/schemas/status'
+                message:
+                  $ref: '#/components/schemas/message'
+              required:
+              - status
+              - message
+              type:
+              - object
+  /users/{user_preferences_identity}/preferences:
+    get:
+      summary: List
+      description: Retrieve User Preferences
+      operationId: user_preferencesList
+      tags:
+      - misc
+      parameters:
+      - name: user_preferences_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of user-preferences.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/user-preferences'
+      x-stackQL-resource: user-preferences
+      x-stackQL-method: List
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update User Preferences
+      operationId: user_preferencesUpdate
+      tags:
+      - misc
+      parameters:
+      - name: user_preferences_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of user-preferences.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/user-preferences'
+      x-stackQL-resource: user-preferences
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type:
+              - object
+              properties:
+                timezone:
+                  $ref: '#/components/schemas/timezone'
+                default-organization:
+                  $ref: '#/components/schemas/default-organization'
+                dismissed-github-banner:
+                  $ref: '#/components/schemas/dismissed-github-banner'
+                dismissed-getting-started:
+                  $ref: '#/components/schemas/dismissed-getting-started'
+                dismissed-org-access-controls:
+                  $ref: '#/components/schemas/dismissed-org-access-controls'
+                dismissed-org-wizard-notification:
+                  $ref: '#/components/schemas/dismissed-org-wizard-notification'
+                dismissed-pipelines-banner:
+                  $ref: '#/components/schemas/dismissed-pipelines-banner'
+                dismissed-pipelines-github-banner:
+                  $ref: '#/components/schemas/dismissed-pipelines-github-banner'
+                dismissed-pipelines-github-banners:
+                  $ref: '#/components/schemas/dismissed-pipelines-github-banners'
+                dismissed-sms-banner:
+                  $ref: '#/components/schemas/dismissed-sms-banner'
+components:
+  schemas:
+    account-delinquency:
+      description: A Heroku account becomes delinquent due to non-payment. We [suspend and delete](https://help.heroku.com/EREVRILX/what-happens-if-i-have-unpaid-heroku-invoices)
+        delinquent accounts if their invoices remain unpaid.
+      type:
+      - object
+      properties:
+        scheduled_suspension_time:
+          $ref: '#/components/schemas/scheduled_suspension_time'
+        scheduled_deletion_time:
+          $ref: '#/components/schemas/scheduled_deletion_time'
+    scheduled_suspension_time:
+      description: scheduled time of when we will suspend your account due to delinquency
+      format: date-time
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    scheduled_deletion_time:
+      description: scheduled time of when we will delete your account due to delinquency
+      format: date-time
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    add-on-region-capability:
+      description: Add-on region capabilities represent the relationship between an Add-on Service and a specific Region.
+        Only Beta and GA add-ons are returned by these endpoints.
+      type:
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        supports_private_networking:
+          $ref: '#/components/schemas/supports_private_networking'
+        addon_service:
+          $ref: '#/components/schemas/add-on-service'
+        region:
+          $ref: '#/components/schemas/region'
+    id:
+      description: unique identifier of this add-on-region-capability
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    supports_private_networking:
+      description: whether the add-on can be installed to a Space
+      readOnly: true
+      type:
+      - boolean
+    add-on-service:
+      description: Add-on services represent add-ons that may be provisioned for apps. Endpoints under add-on services can
+        be accessed without authentication.
+      type:
+      - object
+      properties:
+        cli_plugin_name:
+          $ref: '#/components/schemas/cli_plugin_name'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        human_name:
+          $ref: '#/components/schemas/human_name'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        state:
+          $ref: '#/components/schemas/state'
+        supports_multiple_installations:
+          $ref: '#/components/schemas/supports_multiple_installations'
+        supports_sharing:
+          $ref: '#/components/schemas/supports_sharing'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        supported_generations:
+          $ref: '#/components/schemas/supported_generations'
+    cli_plugin_name:
+      description: npm package name of the add-on service's Heroku CLI plugin
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    created_at:
+      description: when add-on-service was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    human_name:
+      description: human-readable name of the add-on service provider
+      readOnly: true
+      type:
+      - string
+    name:
+      description: unique name of this add-on-service
+      readOnly: true
+      type:
+      - string
+    state:
+      description: release status for add-on service
+      enum:
+      - alpha
+      - beta
+      - ga
+      - shutdown
+      readOnly: true
+      type:
+      - string
+    supports_multiple_installations:
+      default: false
+      description: whether or not apps can have access to more than one instance of this add-on at the same time
+      readOnly: true
+      type:
+      - boolean
+    supports_sharing:
+      default: false
+      description: whether or not apps can have access to add-ons billed to a different app
+      readOnly: true
+      type:
+      - boolean
+    updated_at:
+      description: when add-on-service was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    supported_generations:
+      description: generations supported by this add-on
+      readonly: true
+      type:
+      - array
+      items:
+        type:
+        - object
+        properties:
+          name:
+            $ref: '#/components/schemas/name'
+          id:
+            $ref: '#/components/schemas/id'
+    region:
+      description: A region represents a geographic location in which your application may run.
+      type:
+      - object
+      properties:
+        country:
+          $ref: '#/components/schemas/country'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        description:
+          $ref: '#/components/schemas/description'
+        id:
+          $ref: '#/components/schemas/id'
+        locale:
+          $ref: '#/components/schemas/locale'
+        name:
+          $ref: '#/components/schemas/name'
+        private_capable:
+          $ref: '#/components/schemas/private_capable'
+        provider:
+          $ref: '#/components/schemas/provider'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    country:
+      description: country where the region exists
+      readOnly: true
+      type:
+      - string
+    description:
+      description: description of region
+      readOnly: true
+      type:
+      - string
+    locale:
+      description: area in the country where the region exists
+      readOnly: true
+      type:
+      - string
+    private_capable:
+      description: whether or not region is available for creating a Private Space
+      readOnly: true
+      type:
+      - boolean
+    provider:
+      description: provider of underlying substrate
+      type:
+      - object
+      properties:
+        name:
+          description: name of provider
+          readOnly: true
+          type:
+          - string
+        region:
+          description: region name used by provider
+          readOnly: true
+          type:
+          - string
+          enum:
+          - ap-south-1
+          - eu-west-1
+          - ap-southeast-1
+          - ap-southeast-2
+          - eu-central-1
+          - eu-west-2
+          - ap-northeast-2
+          - ap-northeast-1
+          - us-east-1
+          - sa-east-1
+          - us-west-1
+          - us-west-2
+          - ca-central-1
+      readOnly: true
+    app-webhook-delivery:
+      description: Represents the delivery of a webhook notification, including its current status.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        event:
+          description: identity of event
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            include:
+              $ref: '#/components/schemas/include'
+          type:
+          - object
+        id:
+          $ref: '#/components/schemas/id'
+        num_attempts:
+          $ref: '#/components/schemas/num_attempts'
+        next_attempt_at:
+          $ref: '#/components/schemas/next_attempt_at'
+        last_attempt:
+          description: last attempt of a delivery
+          properties:
+            id:
+              $ref: '#/components/schemas/attempt_id'
+            code:
+              $ref: '#/components/schemas/attempt_code'
+            error_class:
+              $ref: '#/components/schemas/attempt_error_class'
+            status:
+              $ref: '#/components/schemas/attempt_status'
+            created_at:
+              $ref: '#/components/schemas/attempt_created_at'
+            updated_at:
+              $ref: '#/components/schemas/attempt_updated_at'
+          type:
+          - object
+          - 'null'
+        status:
+          $ref: '#/components/schemas/status'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        webhook:
+          description: identity of webhook
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            level:
+              $ref: '#/components/schemas/level'
+          type:
+          - object
+    include:
+      description: the type of entity that the event is related to
+      type:
+      - string
+    num_attempts:
+      description: number of times a delivery has been attempted
+      readOnly: true
+      type:
+      - integer
+    next_attempt_at:
+      description: when delivery will be attempted again
+      format: date-time
+      type:
+      - string
+      - 'null'
+    attempt_id:
+      description: unique identifier of attempt
+      readOnly: true
+      format: uuid
+      type:
+      - string
+    attempt_code:
+      description: http response code received during attempt
+      readOnly: true
+      type:
+      - integer
+      - 'null'
+    attempt_error_class:
+      description: error class encountered during attempt
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    attempt_status:
+      description: status of an attempt
+      enum:
+      - scheduled
+      - succeeded
+      - failed
+      type:
+      - string
+    attempt_created_at:
+      description: when attempt was created
+      format: date-time
+      type:
+      - string
+    attempt_updated_at:
+      description: when attempt was updated
+      format: date-time
+      type:
+      - string
+    status:
+      description: the delivery's status
+      enum:
+      - pending
+      - scheduled
+      - retrying
+      - failed
+      - succeeded
+      type:
+      - string
+    level:
+      description: if `notify`, Heroku makes a single, fire-and-forget delivery attempt. If `sync`, Heroku attempts multiple
+        deliveries until the request is successful or a limit is reached
+      enum:
+      - notify
+      - sync
+      type:
+      - string
+    app-webhook-event:
+      description: Represents a webhook event that occurred.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        include:
+          $ref: '#/components/schemas/include'
+        payload:
+          $ref: '#/components/schemas/payload'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    payload:
+      description: payload of event
+      properties:
+        action:
+          $ref: '#/components/schemas/action'
+        actor:
+          $ref: '#/components/schemas/actor'
+        data:
+          $ref: '#/components/schemas/data'
+        previous_data:
+          $ref: '#/components/schemas/previous_data'
+        resource:
+          $ref: '#/components/schemas/resource'
+        version:
+          $ref: '#/components/schemas/version'
+      type:
+      - object
+    action:
+      description: the type of event that occurred
+      type:
+      - string
+    actor:
+      description: user that caused event
+      properties:
+        email:
+          $ref: '#/components/schemas/email'
+        id:
+          $ref: '#/components/schemas/id'
+      type:
+      - object
+    email:
+      description: unique email address of account
+      format: email
+      readOnly: false
+      type:
+      - string
+    data:
+      description: the current details of the event
+      type:
+      - object
+    previous_data:
+      description: previous details of the event (if any)
+      type:
+      - object
+    resource:
+      description: the type of resource associated with the event
+      type:
+      - string
+    version:
+      description: the version of the details provided for the event
+      type:
+      - string
+    addon_webhook:
+      properties:
+        addon:
+          description: identity of add-on. Only used for add-on partner webhooks.
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        include:
+          $ref: '#/components/schemas/include'
+        level:
+          $ref: '#/components/schemas/level'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        url:
+          $ref: '#/components/schemas/url'
+      description: add-on webhook
+      type:
+      - object
+    url:
+      description: the URL where the webhook's notification requests are sent
+      format: uri
+      type:
+      - string
+    authorization:
+      description: a custom `Authorization` header that Heroku will include with all webhook notifications
+      type:
+      - 'null'
+      - string
+    secret:
+      description: "a value that Heroku will use to sign all webhook notification requests (the signature is included in the\
+        \ request\xE2\u20AC\u2122s `Heroku-Webhook-Hmac-SHA256` header)"
+      type:
+      - 'null'
+      - string
+    credit:
+      description: A credit represents value that will be used up before further charges are assigned to an account.
+      type:
+      - object
+      properties:
+        amount:
+          $ref: '#/components/schemas/amount'
+        balance:
+          $ref: '#/components/schemas/balance'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        expires_at:
+          $ref: '#/components/schemas/expires_at'
+        id:
+          $ref: '#/components/schemas/id'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    amount:
+      description: total value of credit in cents
+      type:
+      - number
+    balance:
+      description: remaining value of credit in cents
+      type:
+      - number
+    expires_at:
+      description: when credit will expire
+      format: date-time
+      type:
+      - string
+    enterprise-account-daily-usage:
+      description: Usage for an enterprise account at a daily resolution.
+      type:
+      - object
+      properties:
+        addons:
+          $ref: '#/components/schemas/addons'
+        teams:
+          description: usage by team
+          type:
+          - array
+          items:
+            type:
+            - object
+            properties:
+              addons:
+                $ref: '#/components/schemas/addons'
+              apps:
+                description: app usage in the team
+                type:
+                - array
+                items:
+                  $ref: '#/components/schemas/app_usage_daily'
+              data:
+                $ref: '#/components/schemas/data'
+              dynos:
+                $ref: '#/components/schemas/dynos'
+              id:
+                $ref: '#/components/schemas/id'
+              name:
+                $ref: '#/components/schemas/name'
+              partner:
+                $ref: '#/components/schemas/partner'
+              space:
+                $ref: '#/components/schemas/space'
+        data:
+          $ref: '#/components/schemas/data'
+        date:
+          $ref: '#/components/schemas/date'
+        dynos:
+          $ref: '#/components/schemas/dynos'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        partner:
+          $ref: '#/components/schemas/partner'
+        space:
+          $ref: '#/components/schemas/space'
+    addons:
+      description: total add-on credits used
+      readOnly: true
+      type:
+      - number
+    app_usage_daily:
+      description: Usage for an app at a daily resolution.
+      type:
+      - object
+      properties:
+        addons:
+          $ref: '#/components/schemas/addons'
+        app_name:
+          $ref: '#/components/schemas/name'
+        data:
+          $ref: '#/components/schemas/data'
+        dynos:
+          $ref: '#/components/schemas/dynos'
+        partner:
+          $ref: '#/components/schemas/partner'
+    dynos:
+      description: dynos used
+      readOnly: true
+      type:
+      - number
+    partner:
+      description: total add-on credits used for third party add-ons
+      readOnly: true
+      type:
+      - number
+    space:
+      description: space credits used
+      readOnly: true
+      type:
+      - number
+    date:
+      description: date of the usage
+      format: date
+      readOnly: true
+      type:
+      - string
+    start_date:
+      description: range start date
+      pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+      readOnly: true
+      type:
+      - string
+    end_date:
+      description: range end date
+      pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+      readOnly: true
+      type:
+      - string
+    enterprise-account-member:
+      description: Enterprise account members are users with access to an enterprise account.
+      type:
+      - object
+      properties:
+        enterprise_account:
+          type:
+          - object
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+        id:
+          $ref: '#/components/schemas/id'
+        permissions:
+          $ref: '#/components/schemas/expanded_permissions'
+        user:
+          description: user information for the membership
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        two_factor_authentication:
+          $ref: '#/components/schemas/two_factor_authentication'
+        identity_provider:
+          $ref: '#/components/schemas/identity_provider'
+    expanded_permissions:
+      description: enterprise account permissions
+      type:
+      - array
+      items:
+        type:
+        - object
+        properties:
+          description:
+            type:
+            - string
+          name:
+            $ref: '#/components/schemas/permission'
+    permission:
+      description: permission in the enterprise account
+      enum:
+      - view
+      - create
+      - manage
+      - billing
+      readOnly: true
+      type:
+      - string
+    two_factor_authentication:
+      description: whether the Enterprise Account member has two factor authentication enabled
+      readOnly: true
+      type:
+      - boolean
+    identity_provider:
+      description: Identity Provider information the member is federated with
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          description: name of the identity provider
+          readOnly: true
+          type:
+          - string
+        redacted:
+          description: whether the identity_provider information is redacted or not
+          readOnly: true
+          type:
+          - boolean
+        owner:
+          $ref: '#/components/schemas/owner'
+      type:
+      - 'null'
+      - object
+    owner:
+      description: entity that owns this identity provider
+      properties:
+        id:
+          description: unique identifier of the owner
+          format: uuid
+          readOnly: true
+          type:
+          - string
+        name:
+          description: name of the owner
+          readOnly: true
+          type:
+          - string
+        type:
+          description: type of the owner
+          enum:
+          - team
+          - enterprise-account
+          readOnly: true
+          type:
+          - string
+      readOnly: false
+      required:
+      - id
+      - type
+      type:
+      - object
+    user_identity:
+      anyOf:
+      - $ref: '#/components/schemas/email'
+      - $ref: '#/components/schemas/id'
+    permissions:
+      description: permissions for enterprise account
+      readOnly: true
+      type:
+      - array
+      items:
+        $ref: '#/components/schemas/permission'
+    enterprise-account-monthly-usage:
+      description: Usage for an enterprise account at a monthly resolution.
+      type:
+      - object
+      properties:
+        addons:
+          $ref: '#/components/schemas/addons'
+        teams:
+          description: usage by team
+          type:
+          - array
+          items:
+            type:
+            - object
+            properties:
+              addons:
+                $ref: '#/components/schemas/addons'
+              apps:
+                description: app usage in the team
+                type:
+                - array
+                items:
+                  $ref: '#/components/schemas/app_usage_monthly'
+              connect:
+                $ref: '#/components/schemas/connect'
+              data:
+                $ref: '#/components/schemas/data'
+              dynos:
+                $ref: '#/components/schemas/dynos'
+              id:
+                $ref: '#/components/schemas/id'
+              name:
+                $ref: '#/components/schemas/name'
+              partner:
+                $ref: '#/components/schemas/partner'
+              space:
+                $ref: '#/components/schemas/space'
+        connect:
+          $ref: '#/components/schemas/connect'
+        data:
+          $ref: '#/components/schemas/data'
+        dynos:
+          $ref: '#/components/schemas/dynos'
+        id:
+          $ref: '#/components/schemas/id'
+        month:
+          $ref: '#/components/schemas/month'
+        name:
+          $ref: '#/components/schemas/name'
+        partner:
+          $ref: '#/components/schemas/partner'
+        space:
+          $ref: '#/components/schemas/space'
+    app_usage_monthly:
+      description: Usage for an app at a monthly resolution.
+      type:
+      - object
+      properties:
+        addons:
+          $ref: '#/components/schemas/addons'
+        app_name:
+          $ref: '#/components/schemas/name'
+        data:
+          $ref: '#/components/schemas/data'
+        dynos:
+          $ref: '#/components/schemas/dynos'
+        partner:
+          $ref: '#/components/schemas/partner'
+    connect:
+      description: max connect rows synced
+      readOnly: true
+      type:
+      - number
+    month:
+      description: year and month of the usage
+      pattern: ^[0-9]{4}-[0-9]{2}$
+      readOnly: true
+      type:
+      - string
+    enterprise-account:
+      description: Enterprise accounts allow companies to manage their development teams and billing.
+      type:
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        name:
+          $ref: '#/components/schemas/name'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        permissions:
+          $ref: '#/components/schemas/permissions'
+        trial:
+          $ref: '#/components/schemas/trial'
+        identity_provider:
+          $ref: '#/components/schemas/identity_provider'
+    trial:
+      description: whether the enterprise account is a trial or not
+      readOnly: true
+      type:
+      - boolean
+    team-app:
+      description: A team app encapsulates the team specific functionality of Heroku apps.
+      type:
+      - object
+      properties:
+        archived_at:
+          $ref: '#/components/schemas/archived_at'
+        buildpack_provided_description:
+          $ref: '#/components/schemas/buildpack_provided_description'
+        build_stack:
+          description: identity of the stack that will be used for new builds
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        git_url:
+          $ref: '#/components/schemas/git_url'
+        id:
+          $ref: '#/components/schemas/id'
+        internal_routing:
+          $ref: '#/components/schemas/internal_routing'
+        joined:
+          $ref: '#/components/schemas/joined'
+        locked:
+          $ref: '#/components/schemas/locked'
+        maintenance:
+          $ref: '#/components/schemas/maintenance'
+        name:
+          $ref: '#/components/schemas/name'
+        team:
+          description: team that owns this app
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - 'null'
+          - object
+        owner:
+          description: identity of app owner
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - 'null'
+          - object
+        region:
+          description: identity of app region
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        released_at:
+          $ref: '#/components/schemas/released_at'
+        repo_size:
+          $ref: '#/components/schemas/repo_size'
+        slug_size:
+          $ref: '#/components/schemas/slug_size'
+        space:
+          description: identity of space
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - 'null'
+          - object
+        stack:
+          description: identity of app stack
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        web_url:
+          $ref: '#/components/schemas/web_url'
+    archived_at:
+      description: when app was archived
+      format: date-time
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    buildpack_provided_description:
+      description: description from buildpack of app
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    git_url:
+      description: git repo URL of app
+      pattern: ^https://git\.heroku\.com/[a-z][a-z0-9-]{2,29}\.git$
+      readOnly: true
+      type:
+      - string
+    internal_routing:
+      default: false
+      description: describes whether a Private Spaces app is externally routable or not
+      readOnly: false
+      type:
+      - boolean
+      - 'null'
+    joined:
+      default: false
+      description: is the current member a collaborator on this app.
+      type:
+      - boolean
+    locked:
+      default: false
+      description: are other team members forbidden from joining this app.
+      type:
+      - boolean
+    maintenance:
+      default: false
+      description: maintenance status of app
+      readOnly: false
+      type:
+      - boolean
+    released_at:
+      default: null
+      description: when app was released
+      format: date-time
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    repo_size:
+      default: null
+      description: git repo size in bytes of app
+      readOnly: true
+      type:
+      - integer
+      - 'null'
+    slug_size:
+      default: null
+      description: slug size in bytes of app
+      readOnly: true
+      type:
+      - integer
+      - 'null'
+    web_url:
+      description: web URL of app
+      format: uri
+      pattern: ^https?://[a-z][a-z0-9-]{3,43}\.herokuapp\.com/$
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    filter:
+      type:
+      - object
+      properties:
+        in:
+          $ref: '#/components/schemas/in'
+    in:
+      type:
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+    generation:
+      description: A generation represents a version of the Heroku platform that includes the app execution environment, routing,
+        telemetry, and build systems.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    identity-provider:
+      description: Identity Providers represent the SAML configuration of teams or an Enterprise account
+      type:
+      - object
+      properties:
+        certificate:
+          $ref: '#/components/schemas/certificate'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        entity_id:
+          $ref: '#/components/schemas/entity_id'
+        id:
+          $ref: '#/components/schemas/id'
+        slo_target_url:
+          $ref: '#/components/schemas/slo_target_url'
+        sso_target_url:
+          $ref: '#/components/schemas/sso_target_url'
+        organization:
+          description: team associated with this identity provider
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - 'null'
+          - object
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        owner:
+          $ref: '#/components/schemas/owner'
+    certificate:
+      description: 'raw contents of the public certificate (eg: .crt or .pem file)'
+      readOnly: false
+      type:
+      - string
+    entity_id:
+      description: URL identifier provided by the identity provider
+      readOnly: false
+      type:
+      - string
+    slo_target_url:
+      description: single log out URL for this identity provider
+      readOnly: false
+      type:
+      - string
+    sso_target_url:
+      description: single sign on URL for this identity provider
+      readOnly: false
+      type:
+      - string
+    inbound-ruleset:
+      description: An inbound-ruleset is a collection of rules that specify what hosts can or cannot connect to an application.
+      type:
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        space:
+          description: identity of space
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        rules:
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/rule'
+        created_by:
+          $ref: '#/components/schemas/email'
+    rule:
+      description: the combination of an IP address in CIDR notation and whether to allow or deny it's traffic.
+      type:
+      - object
+      properties:
+        action:
+          $ref: '#/components/schemas/action'
+        source:
+          $ref: '#/components/schemas/source'
+      required:
+      - source
+      - action
+    source:
+      description: "is the request\xE2\u20AC\u2122s source in CIDR notation"
+      pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+      readOnly: false
+      type:
+      - string
+    invoice-address:
+      description: An invoice address represents the address that should be listed on an invoice.
+      type:
+      - object
+      properties:
+        address_1:
+          $ref: '#/components/schemas/address_1'
+        address_2:
+          $ref: '#/components/schemas/address_2'
+        city:
+          $ref: '#/components/schemas/city'
+        country:
+          $ref: '#/components/schemas/country'
+        heroku_id:
+          $ref: '#/components/schemas/identity'
+        other:
+          $ref: '#/components/schemas/other'
+        postal_code:
+          $ref: '#/components/schemas/postal_code'
+        state:
+          $ref: '#/components/schemas/state'
+        use_invoice_address:
+          $ref: '#/components/schemas/use_invoice_address'
+    address_1:
+      type:
+      - string
+      description: invoice street address line 1
+    address_2:
+      type:
+      - string
+      description: invoice street address line 2
+    city:
+      type:
+      - string
+      description: invoice city
+    identity:
+      anyOf:
+      - $ref: '#/components/schemas/heroku_id'
+    heroku_id:
+      type:
+      - string
+      description: heroku_id identifier reference
+      readOnly: true
+    other:
+      type:
+      - string
+      description: metadata / additional information to go on invoice
+    postal_code:
+      type:
+      - string
+      description: invoice zip code
+    use_invoice_address:
+      type:
+      - boolean
+      description: flag to use the invoice address for an account or not
+      default: false
+    invoice:
+      description: An invoice is an itemized bill of goods for an account which includes pricing and charges.
+      type:
+      - object
+      properties:
+        charges_total:
+          $ref: '#/components/schemas/charges_total'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        credits_total:
+          $ref: '#/components/schemas/credits_total'
+        id:
+          $ref: '#/components/schemas/id'
+        number:
+          $ref: '#/components/schemas/number'
+        period_end:
+          $ref: '#/components/schemas/period_end'
+        period_start:
+          $ref: '#/components/schemas/period_start'
+        state:
+          $ref: '#/components/schemas/state'
+        total:
+          $ref: '#/components/schemas/total'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    charges_total:
+      description: total charges on this invoice
+      readOnly: true
+      type:
+      - number
+    credits_total:
+      description: total credits on this invoice
+      readOnly: true
+      type:
+      - number
+    number:
+      description: human readable invoice number
+      readOnly: true
+      type:
+      - integer
+    period_end:
+      description: the ending date that the invoice covers
+      readOnly: true
+      type:
+      - string
+    period_start:
+      description: the starting date that this invoice covers
+      readOnly: true
+      type:
+      - string
+    total:
+      description: combined total of charges and credits on this invoice
+      readOnly: true
+      type:
+      - number
+    password-reset:
+      description: A password reset represents a in-process password reset attempt.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        user:
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+    password:
+      description: current password on the account
+      readOnly: true
+      type:
+      - string
+    password_confirmation:
+      description: confirmation of the new password
+      readOnly: true
+      type:
+      - string
+    peering-info:
+      description: '[Peering Info](https://devcenter.heroku.com/articles/private-space-peering) gives you the information
+        necessary to peer an AWS VPC to a Private Space.'
+      type:
+      - object
+      properties:
+        aws_account_id:
+          $ref: '#/components/schemas/aws_account_id'
+        aws_region:
+          $ref: '#/components/schemas/provider'
+        vpc_id:
+          $ref: '#/components/schemas/vpc_id'
+        vpc_cidr:
+          description: The CIDR range of the Private Space VPC
+          $ref: '#/components/schemas/cidr'
+        dyno_cidr_blocks:
+          description: The CIDR ranges that should be routed to the Private Space VPC.
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/cidr'
+        unavailable_cidr_blocks:
+          description: The CIDR ranges that you must not conflict with.
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/cidr'
+        space_cidr_blocks:
+          description: The CIDR ranges that should be routed to the Private Space VPC.
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/cidr'
+    aws_account_id:
+      description: The AWS account ID of your Private Space.
+      readOnly: true
+      type:
+      - string
+    vpc_id:
+      description: The AWS VPC ID of the peer.
+      readOnly: true
+      type:
+      - string
+    cidr:
+      description: An IP address and the number of significant bits that make up the routing or networking portion.
+      type:
+      - string
+    permission-entity:
+      description: An owned entity including users' permissions.
+      type:
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        team_id:
+          $ref: '#/components/schemas/id'
+        type:
+          $ref: '#/components/schemas/type'
+        users:
+          description: Users that have access to the entity.
+          items:
+            type:
+            - object
+            properties:
+              email:
+                $ref: '#/components/schemas/email'
+              id:
+                $ref: '#/components/schemas/id'
+              permissions:
+                description: enterprise account permissions
+                type:
+                - array
+                items:
+                  type:
+                  - string
+          type:
+          - array
+    type:
+      description: The type of object the entity is referring to.
+      readOnly: true
+      type:
+      - string
+      enum:
+      - app
+      - space
+    pipeline-build:
+      description: Information about the latest builds of apps in a pipeline. A build represents the process of transforming
+        code into build artifacts.
+      type:
+      - object
+      properties:
+        app:
+          description: app that the build belongs to
+          properties:
+            id:
+              description: unique identifier of the app
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        buildpacks:
+          $ref: '#/components/schemas/buildpacks'
+        created_at:
+          description: when the build was created
+          $ref: '#/components/schemas/created_at'
+        id:
+          description: unique identifier of the build
+          $ref: '#/components/schemas/id'
+        output_stream_url:
+          description: streaming URL of the build process output
+          $ref: '#/components/schemas/output_stream_url'
+        source_blob:
+          description: location of gzipped tarball of source code used to create build
+          properties:
+            checksum:
+              description: an optional checksum of the gzipped tarball for verifying its integrity
+              readOnly: true
+              type:
+              - 'null'
+              - string
+            url:
+              description: URL where gzipped tar archive of source code for build was downloaded.
+              readOnly: true
+              type:
+              - string
+            version:
+              description: version of the gzipped tarball
+              readOnly: true
+              type:
+              - string
+              - 'null'
+            version_description:
+              description: version description of the gzipped tarball
+              readOnly: true
+              type:
+              - string
+              - 'null'
+          type:
+          - object
+        release:
+          properties:
+            id:
+              description: unique identifier of the release
+              $ref: '#/components/schemas/id'
+          $ref: '#/components/schemas/release'
+        slug:
+          description: slug created by this build
+          properties:
+            id:
+              description: unique identifier of the slug
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+          - 'null'
+        stack:
+          description: stack of the build
+          $ref: '#/components/schemas/stack'
+        status:
+          description: status of the build
+          $ref: '#/components/schemas/status'
+        updated_at:
+          description: when the build was updated
+          $ref: '#/components/schemas/updated_at'
+        user:
+          description: user that started the build
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            email:
+              $ref: '#/components/schemas/email'
+          type:
+          - object
+    buildpacks:
+      description: buildpacks executed for this build, in order (only applicable to Cedar-generation apps)
+      type:
+      - array
+      - 'null'
+      items:
+        description: Buildpack to execute in a build
+        type:
+        - object
+        properties:
+          url:
+            description: the URL of the buildpack for the app
+            readOnly: false
+            type:
+            - string
+          name:
+            description: Buildpack Registry name of the buildpack for the app
+            readOnly: false
+            type:
+            - string
+    output_stream_url:
+      description: Build process output will be available from this URL as a stream. The stream is available as either `text/plain`
+        or `text/event-stream`. Clients should be prepared to handle disconnects and can resume the stream by sending a `Range`
+        header (for `text/plain`) or a `Last-Event-Id` header (for `text/event-stream`).
+      readOnly: true
+      type:
+      - string
+    release:
+      description: release resulting from the build
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+      readOnly: true
+      type:
+      - 'null'
+      - object
+    stack:
+      description: stack of build
+      readOnly: true
+      type:
+      - string
+    config_vars:
+      additionalProperties: false
+      description: hash of config vars
+      patternProperties:
+        ^[\w\.\:\[\]]+$:
+          type:
+          - string
+          - 'null'
+      type:
+      - object
+    pipeline-promotion-target:
+      description: Promotion targets represent an individual app being promoted to
+      type:
+      - object
+      properties:
+        app:
+          description: the app which was promoted to
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        error_message:
+          $ref: '#/components/schemas/error_message'
+        id:
+          $ref: '#/components/schemas/id'
+        pipeline_promotion:
+          description: the promotion which the target belongs to
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        release:
+          description: the release which was created on the target app
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+          - 'null'
+        status:
+          $ref: '#/components/schemas/status'
+    error_message:
+      description: an error message for why the promotion failed
+      type:
+      - 'null'
+      - string
+    pipeline-stack:
+      description: A pipeline's stack is determined by the apps in the pipeline. This is used during creation of CI and Review
+        Apps that have no stack defined in app.json
+      type:
+      - object
+      properties:
+        stack:
+          description: identity of the stack that will be used for new builds without a stack defined in CI and Review Apps
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+          - 'null'
+    pipeline-transfer:
+      description: A pipeline transfer is the process of changing pipeline ownership along with the contained apps.
+      type:
+      - object
+      properties:
+        pipeline:
+          description: pipeline being transferred
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        previous_owner:
+          $ref: '#/components/schemas/previous_owner'
+        new_owner:
+          $ref: '#/components/schemas/new_owner'
+    previous_owner:
+      description: Previous owner of the pipeline.
+      $ref: '#/components/schemas/owner'
+      type:
+      - object
+    new_owner:
+      description: New owner of the pipeline.
+      $ref: '#/components/schemas/owner'
+      type:
+      - object
+    rate-limit:
+      description: Rate Limit represents the number of request tokens each account holds. Requests to this endpoint do not
+        count towards the rate limit.
+      type:
+      - object
+      properties:
+        remaining:
+          $ref: '#/components/schemas/remaining'
+    remaining:
+      description: allowed requests remaining in current interval
+      readOnly: true
+      type:
+      - integer
+    review-app:
+      description: An ephemeral app to review a set of changes
+      type:
+      - object
+      properties:
+        app:
+          description: the Heroku app associated to this review app
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - 'null'
+          - object
+        app_setup:
+          description: the app setup for this review app
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - 'null'
+          - object
+        branch:
+          $ref: '#/components/schemas/branch'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        pipeline:
+          description: the pipeline which this review app belongs to
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        status:
+          $ref: '#/components/schemas/status'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        creator:
+          $ref: '#/components/schemas/creator'
+        wait_for_ci:
+          $ref: '#/components/schemas/wait_for_ci'
+        error_status:
+          $ref: '#/components/schemas/error_status'
+        message:
+          $ref: '#/components/schemas/message'
+        fork_repo:
+          properties:
+            id:
+              $ref: '#/components/schemas/fork_repo_id'
+          type:
+          - object
+          - 'null'
+        pr_number:
+          $ref: '#/components/schemas/pr_number'
+    branch:
+      description: the branch of the repository which the review app is based on
+      readOnly: true
+      type:
+      - string
+    creator:
+      description: The user who created the review app
+      readOnly: true
+      type:
+      - object
+    wait_for_ci:
+      description: wait for ci before building the app
+      readOnly: true
+      type:
+      - boolean
+    error_status:
+      description: error message from creating the review app if any
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    message:
+      description: message from creating the review app if any
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    fork_repo_id:
+      description: repository id of the fork the branch resides in
+      readOnly: true
+      type:
+      - integer
+      - 'null'
+    pr_number:
+      description: pull request number the review app is built for
+      readOnly: true
+      type:
+      - integer
+      - 'null'
+    source_blob:
+      description: The download location for the review app's source code
+      properties:
+        url:
+          description: URL where gzipped tar archive of source code for build was downloaded.
+          readOnly: true
+          type:
+          - string
+        version:
+          description: The version number (or SHA) of the code to build.
+          type:
+          - string
+          - 'null'
+      type:
+      - object
+    review-app-config:
+      description: Review apps can be configured for pipelines.
+      type:
+      - object
+      properties:
+        repo:
+          properties:
+            id:
+              $ref: '#/components/schemas/repo_id'
+          type:
+          - object
+        automatic_review_apps:
+          $ref: '#/components/schemas/automatic_review_apps'
+        deploy_target:
+          $ref: '#/components/schemas/deploy_target'
+        destroy_stale_apps:
+          $ref: '#/components/schemas/destroy_stale_apps'
+        stale_days:
+          $ref: '#/components/schemas/stale_days'
+        pipeline_id:
+          $ref: '#/components/schemas/id'
+        wait_for_ci:
+          $ref: '#/components/schemas/wait_for_ci'
+        base_name:
+          $ref: '#/components/schemas/base_name'
+    repo_id:
+      description: repository id
+      readOnly: true
+      type:
+      - integer
+    automatic_review_apps:
+      description: enable automatic review apps for pull requests
+      readOnly: true
+      type:
+      - boolean
+    deploy_target:
+      description: the deploy target for the review apps of a pipeline
+      properties:
+        id:
+          $ref: '#/components/schemas/deploy_target'
+        type:
+          $ref: '#/components/schemas/deploy_target'
+      required:
+      - id
+      - type
+      type:
+      - object
+      - 'null'
+    destroy_stale_apps:
+      description: automatically destroy review apps when they haven't been deployed for a number of days
+      readOnly: true
+      type:
+      - boolean
+    stale_days:
+      description: number of days without a deployment after which to consider a review app stale
+      readOnly: true
+      type:
+      - integer
+    base_name:
+      description: A unique prefix that will be used to create review app names
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    repo:
+      description: repository name
+      readOnly: true
+      type:
+      - string
+    sms-number:
+      description: SMS numbers are used for recovery on accounts with two-factor authentication enabled.
+      type:
+      - object
+      properties:
+        sms_number:
+          $ref: '#/components/schemas/sms_number'
+    sms_number:
+      description: SMS number of account
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    space-app-access:
+      description: Space access represents the permissions a particular user has on a particular space.
+      type:
+      - object
+      properties:
+        space:
+          description: space user belongs to
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        permissions:
+          description: user space permissions
+          type:
+          - array
+          items:
+            type:
+            - object
+            properties:
+              description:
+                type:
+                - string
+              name:
+                type:
+                - string
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        user:
+          description: identity of user account
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+    space-nat:
+      description: Network address translation (NAT) for stable outbound IP addresses from a space
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        sources:
+          $ref: '#/components/schemas/sources'
+        state:
+          $ref: '#/components/schemas/state'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    sources:
+      description: potential IPs from which outbound network traffic will originate
+      readOnly: true
+      type:
+      - array
+      items:
+        $ref: '#/components/schemas/ip_v4_address'
+    ip_v4_address:
+      format: ipv4
+      pattern: ^(([01]?\d?\d|2[0-4]\d|25[0-5])\.){3}([01]?\d?\d|2[0-4]\d|25[0-5])$
+      type:
+      - string
+    space-topology:
+      description: Space Topology provides you with a mechanism for viewing all the running dynos, formations and applications
+        for a space. This is the same data thats used to power our DNS Service Discovery.
+      type:
+      - object
+      properties:
+        version:
+          $ref: '#/components/schemas/version'
+        apps:
+          description: The apps within this space
+          type:
+          - array
+          readOnly: true
+          items:
+            type:
+            - object
+            properties:
+              id:
+                $ref: '#/components/schemas/id'
+                readOnly: true
+              domains:
+                readOnly: true
+                type:
+                - array
+              formation:
+                description: formations for application
+                items:
+                  $ref: '#/components/schemas/formation'
+                type:
+                - array
+                readOnly: true
+    formation:
+      description: formations for application
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        process_type:
+          description: Name of process type
+          type:
+          - string
+        dynos:
+          description: Current dynos for application
+          items:
+            $ref: '#/components/schemas/dyno'
+          type:
+          - array
+      type:
+      - object
+    dyno:
+      description: A dyno
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        number:
+          description: process number, e.g. 1 in web.1
+          type:
+          - integer
+        private_ip:
+          description: RFC1918 Address of Dyno
+          type:
+          - string
+        hostname:
+          description: localspace hostname of resource
+          type:
+          - string
+      type:
+      - object
+    add-on:
+      description: Add-ons represent add-ons that have been provisioned and attached to one or more apps.
+      additionalProperties: false
+      required:
+      - actions
+      - addon_service
+      - billing_entity
+      - app
+      - billed_price
+      - config_vars
+      - created_at
+      - id
+      - name
+      - plan
+      - provider_id
+      - state
+      - updated_at
+      - web_url
+      type:
+      - object
+      properties:
+        actions:
+          $ref: '#/components/schemas/actions'
+        addon_service:
+          $ref: '#/components/schemas/addon_service'
+        billing_entity:
+          description: billing entity associated with this add-on
+          type:
+          - object
+          properties:
+            id:
+              description: unique identifier of the billing entity
+              format: uuid
+              readOnly: true
+              type:
+              - string
+            name:
+              description: name of the billing entity
+              readOnly: true
+              type:
+              - string
+            type:
+              description: type of Object of the billing entity; new types allowed at any time.
+              enum:
+              - app
+              - team
+              readOnly: true
+              type:
+              - string
+        app:
+          description: billing application associated with this add-on
+          type:
+          - object
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+        billed_price:
+          description: billed price
+          properties:
+            cents:
+              $ref: '#/components/schemas/cents'
+            contract:
+              $ref: '#/components/schemas/contract'
+            unit:
+              $ref: '#/components/schemas/unit'
+          type:
+          - object
+          - 'null'
+        config_vars:
+          $ref: '#/components/schemas/config_vars'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        plan:
+          $ref: '#/components/schemas/plan'
+        provider_id:
+          $ref: '#/components/schemas/provider_id'
+        provision_message:
+          $ref: '#/components/schemas/provision_message'
+        state:
+          $ref: '#/components/schemas/state'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        web_url:
+          $ref: '#/components/schemas/web_url'
+    actions:
+      description: provider actions for this specific add-on
+      type:
+      - array
+      items:
+        type:
+        - object
+      readOnly: true
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        label:
+          $ref: '#/components/schemas/label'
+        action:
+          $ref: '#/components/schemas/action'
+        url:
+          $ref: '#/components/schemas/url'
+        requires_owner:
+          $ref: '#/components/schemas/requires_owner'
+    label:
+      description: the display text shown in Dashboard
+      readOnly: true
+      type:
+      - string
+    requires_owner:
+      description: if the action requires the user to own the app
+      readOnly: true
+      type:
+      - boolean
+    addon_service:
+      description: identity of add-on service
+      anyOf:
+      - properties:
+          id:
+            $ref: '#/components/schemas/id'
+          name:
+            $ref: '#/components/schemas/name'
+        strictProperties: true
+        type:
+        - object
+      - $ref: '#/components/schemas/add-on-service'
+    cents:
+      description: price in cents per unit of plan
+      readOnly: true
+      type:
+      - integer
+    contract:
+      description: price is negotiated in a contract outside of monthly add-on billing
+      readOnly: true
+      type:
+      - boolean
+    unit:
+      description: unit of price for plan
+      readOnly: true
+      type:
+      - string
+    plan:
+      description: identity of add-on plan
+      anyOf:
+      - properties:
+          id:
+            $ref: '#/components/schemas/id'
+          name:
+            $ref: '#/components/schemas/name'
+        strictProperties: true
+        type:
+        - object
+      - $ref: '#/components/schemas/plan'
+    provider_id:
+      description: id of this add-on with its provider
+      readOnly: true
+      type:
+      - string
+    provision_message:
+      description: A provision message
+      readOnly: true
+      type:
+      - string
+    team-app-permission:
+      description: A team app permission is a behavior that is assigned to a user in a team app.
+      type:
+      - object
+      properties:
+        name:
+          $ref: '#/components/schemas/name'
+        description:
+          $ref: '#/components/schemas/description'
+    team-daily-usage:
+      description: Usage for an enterprise team at a daily resolution.
+      type:
+      - object
+      properties:
+        addons:
+          $ref: '#/components/schemas/addons'
+        apps:
+          description: app usage in the team
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/app_usage_daily'
+        data:
+          $ref: '#/components/schemas/data'
+        date:
+          $ref: '#/components/schemas/date'
+        dynos:
+          $ref: '#/components/schemas/dynos'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        partner:
+          $ref: '#/components/schemas/partner'
+        space:
+          $ref: '#/components/schemas/space'
+    team-delinquency:
+      description: A Heroku team becomes delinquent due to non-payment. We [suspend and delete](https://help.heroku.com/EREVRILX/what-happens-if-i-have-unpaid-heroku-invoices)
+        delinquent teams if their invoices remain unpaid.
+      type:
+      - object
+      properties:
+        scheduled_suspension_time:
+          $ref: '#/components/schemas/scheduled_suspension_time'
+        scheduled_deletion_time:
+          $ref: '#/components/schemas/scheduled_deletion_time'
+    team-invoice:
+      description: A Team Invoice is an itemized bill of goods for a team which includes pricing and charges.
+      type:
+      - object
+      properties:
+        addons_total:
+          $ref: '#/components/schemas/addons_total'
+        database_total:
+          $ref: '#/components/schemas/database_total'
+        charges_total:
+          $ref: '#/components/schemas/charges_total'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        credits_total:
+          $ref: '#/components/schemas/credits_total'
+        dyno_units:
+          $ref: '#/components/schemas/dyno_units'
+        id:
+          $ref: '#/components/schemas/id'
+        number:
+          $ref: '#/components/schemas/number'
+        payment_status:
+          $ref: '#/components/schemas/payment_status'
+        period_end:
+          $ref: '#/components/schemas/period_end'
+        period_start:
+          $ref: '#/components/schemas/period_start'
+        platform_total:
+          $ref: '#/components/schemas/platform_total'
+        state:
+          $ref: '#/components/schemas/state'
+        total:
+          $ref: '#/components/schemas/total'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        weighted_dyno_hours:
+          $ref: '#/components/schemas/weighted_dyno_hours'
+    addons_total:
+      description: total add-ons charges in on this invoice
+      readOnly: true
+      type:
+      - integer
+    database_total:
+      description: total database charges on this invoice
+      readOnly: true
+      type:
+      - integer
+    dyno_units:
+      description: total amount of dyno units consumed across dyno types.
+      readOnly: true
+      type:
+      - number
+    payment_status:
+      description: status of the invoice payment
+      readOnly: true
+      type:
+      - string
+    platform_total:
+      description: total platform charges on this invoice
+      readOnly: true
+      type:
+      - integer
+    weighted_dyno_hours:
+      description: The total amount of hours consumed across dyno types.
+      readOnly: true
+      type:
+      - number
+    team-monthly-usage:
+      description: Usage for an enterprise team at a monthly resolution.
+      type:
+      - object
+      properties:
+        addons:
+          $ref: '#/components/schemas/addons'
+        apps:
+          description: app usage in the team
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/app_usage_monthly'
+        connect:
+          $ref: '#/components/schemas/connect'
+        data:
+          $ref: '#/components/schemas/data'
+        dynos:
+          $ref: '#/components/schemas/dynos'
+        id:
+          $ref: '#/components/schemas/id'
+        month:
+          $ref: '#/components/schemas/month'
+        name:
+          $ref: '#/components/schemas/name'
+        partner:
+          $ref: '#/components/schemas/partner'
+        space:
+          $ref: '#/components/schemas/space'
+    team-preferences:
+      description: Tracks a Team's Preferences
+      type:
+      - object
+      properties:
+        default-permission:
+          $ref: '#/components/schemas/default-permission'
+        addons-controls:
+          $ref: '#/components/schemas/addons-controls'
+    default-permission:
+      description: The default permission used when adding new members to the team
+      readOnly: false
+      enum:
+      - admin
+      - member
+      - viewer
+      - null
+      type:
+      - 'null'
+      - string
+    addons-controls:
+      description: Whether add-on service rules should be applied to add-on installations
+      readOnly: false
+      type:
+      - boolean
+      - 'null'
+    telemetry-drain:
+      description: A telemetry drain forwards OpenTelemetry traces, metrics, and logs to your own consumer. For Fir-generation
+        apps only.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        owner:
+          $ref: '#/components/schemas/owner'
+        signals:
+          $ref: '#/components/schemas/signals'
+        exporter:
+          $ref: '#/components/schemas/exporter'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    signals:
+      description: OpenTelemetry signals to send to telemetry drain
+      readOnly: false
+      minItems: 1
+      uniqueItems: true
+      type:
+      - array
+      items:
+        $ref: '#/components/schemas/signal'
+    signal:
+      description: OpenTelemetry signal to be sent to the telemetry drain
+      readOnly: true
+      type:
+      - string
+      enum:
+      - traces
+      - metrics
+      - logs
+    exporter:
+      description: OpenTelemetry exporter configuration
+      readOnly: false
+      additionalProperties: false
+      properties:
+        type:
+          $ref: '#/components/schemas/exporter_type'
+        endpoint:
+          $ref: '#/components/schemas/exporter_endpoint'
+        headers:
+          $ref: '#/components/schemas/exporter_headers'
+      required:
+      - type
+      - endpoint
+      type:
+      - object
+    exporter_type:
+      description: the transport type to be used for your OpenTelemetry consumer
+      readOnly: true
+      type:
+      - string
+      enum:
+      - otlphttp
+      - otlp
+    exporter_endpoint:
+      description: URI of your OpenTelemetry consumer
+      readOnly: false
+      maxLength: 1000
+      type:
+      - string
+    exporter_headers:
+      description: JSON headers to send to your OpenTelemetry consumer
+      readOnly: false
+      default: {}
+      additionalProperties: false
+      maxItems: 20
+      patternProperties:
+        ^[A-Za-z0-9\-_]{1,100}$:
+          maxLength: 1000
+          type:
+          - string
+      type:
+      - object
+    test-case:
+      description: A single test case belonging to a test run
+      type:
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        description:
+          $ref: '#/components/schemas/description'
+        diagnostic:
+          $ref: '#/components/schemas/diagnostic'
+        directive:
+          $ref: '#/components/schemas/directive'
+        passed:
+          $ref: '#/components/schemas/passed'
+        number:
+          $ref: '#/components/schemas/number'
+        test_node:
+          description: the test node which executed this test case
+          properties:
+            id:
+              $ref: '#/components/schemas/identity'
+          type:
+          - object
+        test_run:
+          description: the test run which owns this test case
+          properties:
+            id:
+              $ref: '#/components/schemas/identity'
+          type:
+          - object
+    diagnostic:
+      description: meta information about the test case
+      type:
+      - string
+    directive:
+      description: special note about the test case e.g. skipped, todo
+      type:
+      - string
+    passed:
+      description: whether the test case was successful
+      type:
+      - boolean
+    test-node:
+      description: A single test node belonging to a test run
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        dyno:
+          description: the dyno which belongs to this test node
+          properties:
+            id:
+              $ref: '#/components/schemas/identity'
+            attach_url:
+              $ref: '#/components/schemas/attach_url'
+          type:
+          - object
+          - 'null'
+        error_status:
+          $ref: '#/components/schemas/error_status'
+        exit_code:
+          $ref: '#/components/schemas/exit_code'
+        id:
+          $ref: '#/components/schemas/identity'
+        index:
+          $ref: '#/components/schemas/index'
+        message:
+          $ref: '#/components/schemas/message'
+        output_stream_url:
+          $ref: '#/components/schemas/output_stream_url'
+        pipeline:
+          description: the pipeline which owns this test node
+          properties:
+            id:
+              $ref: '#/components/schemas/identity'
+          type:
+          - object
+        setup_stream_url:
+          $ref: '#/components/schemas/setup_stream_url'
+        status:
+          $ref: '#/components/schemas/status'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        test_run:
+          description: the test run which owns this test node
+          properties:
+            id:
+              $ref: '#/components/schemas/identity'
+          type:
+          - object
+    attach_url:
+      description: a URL to stream output from for debug runs or null for non-debug runs
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    exit_code:
+      description: the exit code of the test script
+      type:
+      - integer
+      - 'null'
+    index:
+      description: The index of the test node
+      type:
+      - integer
+    setup_stream_url:
+      description: the streaming test setup output for the test node
+      type:
+      - string
+    commit_branch:
+      description: the branch of the repository that the test run concerns
+      type:
+      - string
+    commit_message:
+      description: the message for the commit under test
+      type:
+      - string
+    commit_sha:
+      description: the SHA hash of the commit under test
+      type:
+      - string
+    debug:
+      description: whether the test run was started for interactive debugging
+      type:
+      - boolean
+    source_blob_url:
+      description: The download location for the source code to be tested
+      type:
+      - string
+    test-run:
+      description: An execution or trial of one or more tests
+      type:
+      - object
+      properties:
+        actor_email:
+          $ref: '#/components/schemas/actor_email'
+        clear_cache:
+          $ref: '#/components/schemas/clear_cache'
+        commit_branch:
+          $ref: '#/components/schemas/commit_branch'
+        commit_message:
+          $ref: '#/components/schemas/commit_message'
+        commit_sha:
+          $ref: '#/components/schemas/commit_sha'
+        debug:
+          $ref: '#/components/schemas/debug'
+        app_setup:
+          $ref: '#/components/schemas/app_setup'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        dyno:
+          description: the type of dynos used for this test-run
+          properties:
+            size:
+              $ref: '#/components/schemas/size'
+          type:
+          - 'null'
+          - object
+        id:
+          $ref: '#/components/schemas/id'
+        message:
+          $ref: '#/components/schemas/message'
+        number:
+          $ref: '#/components/schemas/number'
+        organization:
+          description: the team that owns this test-run
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - 'null'
+          - object
+        pipeline:
+          description: the pipeline which owns this test-run
+          properties:
+            id:
+              $ref: '#/components/schemas/identity'
+          type:
+          - object
+        status:
+          $ref: '#/components/schemas/status'
+        source_blob_url:
+          $ref: '#/components/schemas/source_blob_url'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        user:
+          $ref: '#/components/schemas/account'
+        warning_message:
+          $ref: '#/components/schemas/warning_message'
+    actor_email:
+      description: the email of the actor triggering the test run
+      type:
+      - string
+      format: email
+    clear_cache:
+      description: whether the test was run with an empty cache
+      type:
+      - boolean
+      - 'null'
+    app_setup:
+      description: the app setup for the test run
+      type:
+      - 'null'
+      - object
+    size:
+      description: dyno size
+      readOnly: false
+      type:
+      - string
+    account:
+      description: An account represents an individual signed up to use the Heroku platform.
+      type:
+      - object
+      properties:
+        allow_tracking:
+          $ref: '#/components/schemas/allow_tracking'
+        beta:
+          $ref: '#/components/schemas/beta'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        email:
+          $ref: '#/components/schemas/email'
+        federated:
+          $ref: '#/components/schemas/federated'
+        id:
+          $ref: '#/components/schemas/id'
+        identity_provider:
+          description: Identity Provider details for federated users.
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+            team:
+              type:
+              - object
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+            organization:
+              type:
+              - object
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+            owner:
+              $ref: '#/components/schemas/owner'
+          type:
+          - object
+          - 'null'
+        last_login:
+          $ref: '#/components/schemas/last_login'
+        name:
+          $ref: '#/components/schemas/name'
+        sms_number:
+          $ref: '#/components/schemas/sms_number'
+        suspended_at:
+          $ref: '#/components/schemas/suspended_at'
+        delinquent_at:
+          $ref: '#/components/schemas/delinquent_at'
+        two_factor_authentication:
+          $ref: '#/components/schemas/two_factor_authentication'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        verified:
+          $ref: '#/components/schemas/verified'
+        country_of_residence:
+          $ref: '#/components/schemas/country_of_residence'
+        default_organization:
+          description: team selected by default
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+          - 'null'
+        default_team:
+          description: team selected by default
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+          - 'null'
+    allow_tracking:
+      default: true
+      description: whether to allow third party web activity tracking
+      readOnly: false
+      type:
+      - boolean
+    beta:
+      default: false
+      description: whether allowed to utilize beta Heroku features
+      readOnly: false
+      type:
+      - boolean
+    federated:
+      description: whether the user is federated and belongs to an Identity Provider
+      readOnly: true
+      type:
+      - boolean
+    last_login:
+      description: when account last authorized with Heroku
+      format: date-time
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    suspended_at:
+      description: when account was suspended
+      format: date-time
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    delinquent_at:
+      description: when account became delinquent
+      format: date-time
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    verified:
+      default: false
+      description: whether account has been verified with billing information
+      readOnly: true
+      type:
+      - boolean
+    country_of_residence:
+      description: country where account owner resides
+      readOnly: false
+      type:
+      - string
+      - 'null'
+    warning_message:
+      description: human friently warning emitted during the test run
+      type:
+      - string
+      - 'null'
+    user-preferences:
+      description: Tracks a user's preferences and message dismissals
+      type:
+      - object
+      properties:
+        timezone:
+          $ref: '#/components/schemas/timezone'
+        default-organization:
+          $ref: '#/components/schemas/default-organization'
+        dismissed-github-banner:
+          $ref: '#/components/schemas/dismissed-github-banner'
+        dismissed-getting-started:
+          $ref: '#/components/schemas/dismissed-getting-started'
+        dismissed-org-access-controls:
+          $ref: '#/components/schemas/dismissed-org-access-controls'
+        dismissed-org-wizard-notification:
+          $ref: '#/components/schemas/dismissed-org-wizard-notification'
+        dismissed-pipelines-banner:
+          $ref: '#/components/schemas/dismissed-pipelines-banner'
+        dismissed-pipelines-github-banner:
+          $ref: '#/components/schemas/dismissed-pipelines-github-banner'
+        dismissed-pipelines-github-banners:
+          $ref: '#/components/schemas/dismissed-pipelines-github-banners'
+        dismissed-sms-banner:
+          $ref: '#/components/schemas/dismissed-sms-banner'
+    timezone:
+      description: User's default timezone
+      readOnly: false
+      type:
+      - string
+      - 'null'
+    default-organization:
+      description: User's default team
+      readOnly: false
+      type:
+      - string
+      - 'null'
+    dismissed-github-banner:
+      description: Whether the user has dismissed the GitHub link banner
+      readOnly: false
+      type:
+      - boolean
+      - 'null'
+    dismissed-getting-started:
+      description: Whether the user has dismissed the getting started banner
+      readOnly: false
+      type:
+      - boolean
+      - 'null'
+    dismissed-org-access-controls:
+      description: Whether the user has dismissed the Organization Access Controls banner
+      readOnly: false
+      type:
+      - boolean
+      - 'null'
+    dismissed-org-wizard-notification:
+      description: Whether the user has dismissed the Organization Wizard
+      readOnly: false
+      type:
+      - boolean
+      - 'null'
+    dismissed-pipelines-banner:
+      description: Whether the user has dismissed the Pipelines banner
+      readOnly: false
+      type:
+      - boolean
+      - 'null'
+    dismissed-pipelines-github-banner:
+      description: Whether the user has dismissed the GitHub banner on a pipeline overview
+      readOnly: false
+      type:
+      - boolean
+      - 'null'
+    dismissed-pipelines-github-banners:
+      description: Which pipeline uuids the user has dismissed the GitHub banner for
+      readOnly: false
+      type:
+      - 'null'
+      - array
+      items:
+        $ref: '#/components/schemas/id'
+    dismissed-sms-banner:
+      description: Whether the user has dismissed the 2FA SMS banner
+      readOnly: false
+      type:
+      - boolean
+      - 'null'
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    account-delinquency:
+      id: heroku.misc.account-delinquency
+      name: account-delinquency
+      title: Account Delinquency
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1account~1delinquency/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/account-delinquency/methods/Info'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    add-on-region-capability:
+      id: heroku.misc.add-on-region-capability
+      name: add-on-region-capability
+      title: Add On Region Capability
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1addon-region-capabilities/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByAddOnService:
+          operation:
+            $ref: '#/paths/~1addon-services~1{add_on_service_identity}~1region-capabilities/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByRegion:
+          operation:
+            $ref: '#/paths/~1regions~1{region_identity}~1addon-region-capabilities/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/add-on-region-capability/methods/List'
+        - $ref: '#/components/x-stackQL-resources/add-on-region-capability/methods/ListByAddOnService'
+        - $ref: '#/components/x-stackQL-resources/add-on-region-capability/methods/ListByRegion'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    add-on-webhook-delivery:
+      id: heroku.misc.add-on-webhook-delivery
+      name: add-on-webhook-delivery
+      title: Add On Webhook Delivery
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1webhook-deliveries~1{app_webhook_delivery_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1webhook-deliveries/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/add-on-webhook-delivery/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/add-on-webhook-delivery/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    add-on-webhook-event:
+      id: heroku.misc.add-on-webhook-event
+      name: add-on-webhook-event
+      title: Add On Webhook Event
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1webhook-events~1{app_webhook_event_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1webhook-events/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/add-on-webhook-event/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/add-on-webhook-event/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    add-on-webhook:
+      id: heroku.misc.add-on-webhook
+      name: add-on-webhook
+      title: Add On Webhook
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1webhooks/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1webhooks/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1webhooks~1{app_webhook_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1webhooks~1{app_webhook_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1addons~1{add_on_identity}~1webhooks~1{app_webhook_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/add-on-webhook/methods/List'
+        - $ref: '#/components/x-stackQL-resources/add-on-webhook/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/add-on-webhook/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/add-on-webhook/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/add-on-webhook/methods/Delete'
+        exec: []
+    archive:
+      id: heroku.misc.archive
+      name: archive
+      title: Archive
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_identity}~1archives~1{archive_year}~1{archive_month}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_identity}~1archives/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/archive/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/archive/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    audit-trail-event:
+      id: heroku.misc.audit-trail-event
+      name: audit-trail-event
+      title: Audit Trail Event
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_identity}~1events/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/audit-trail-event/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    credit:
+      id: heroku.misc.credit
+      name: credit
+      title: Credit
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1account~1credits/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1account~1credits/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Info:
+          operation:
+            $ref: '#/paths/~1account~1credits~1{credit_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/credit/methods/List'
+        - $ref: '#/components/x-stackQL-resources/credit/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/credit/methods/Create'
+        update: []
+        delete: []
+        exec: []
+    enterprise-account-daily-usage:
+      id: heroku.misc.enterprise-account-daily-usage
+      name: enterprise-account-daily-usage
+      title: Enterprise Account Daily Usage
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_id}~1usage~1daily/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/enterprise-account-daily-usage/methods/Info'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    enterprise-account-member:
+      id: heroku.misc.enterprise-account-member
+      name: enterprise-account-member
+      title: Enterprise Account Member
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_identity}~1members/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Create:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_identity}~1members/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        Update:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_identity}~1members~1{enterprise_account_member_user_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_identity}~1members~1{enterprise_account_member_user_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/enterprise-account-member/methods/List'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/enterprise-account-member/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/enterprise-account-member/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/enterprise-account-member/methods/Delete'
+        exec: []
+    enterprise-account-monthly-usage:
+      id: heroku.misc.enterprise-account-monthly-usage
+      name: enterprise-account-monthly-usage
+      title: Enterprise Account Monthly Usage
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_id}~1usage~1monthly/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/enterprise-account-monthly-usage/methods/Info'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    enterprise-account:
+      id: heroku.misc.enterprise-account
+      name: enterprise-account
+      title: Enterprise Account
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Info:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/enterprise-account/methods/List'
+        - $ref: '#/components/x-stackQL-resources/enterprise-account/methods/Info'
+        insert: []
+        update: []
+        delete: []
+        exec:
+        - $ref: '#/components/x-stackQL-resources/enterprise-account/methods/Update'
+    filter-apps:
+      id: heroku.misc.filter-apps
+      name: filter-apps
+      title: Filter Apps
+      methods:
+        Apps:
+          operation:
+            $ref: '#/paths/~1filters~1apps/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/filter-apps/methods/Apps'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    generation:
+      id: heroku.misc.generation
+      name: generation
+      title: Generation
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1generations~1{stack_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1generations/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1available-generations/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/generation/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/generation/methods/List'
+        - $ref: '#/components/x-stackQL-resources/generation/methods/ListByTeam'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    identity-provider:
+      id: heroku.misc.identity-provider
+      name: identity-provider
+      title: Identity Provider
+      methods:
+        ListByTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_name}~1identity-providers/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        CreateByTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_name}~1identity-providers/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        UpdateByTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_name}~1identity-providers~1{identity_provider_id}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        DeleteByTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_name}~1identity-providers~1{identity_provider_id}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/identity-provider/methods/ListByTeam'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/identity-provider/methods/CreateByTeam'
+        update:
+        - $ref: '#/components/x-stackQL-resources/identity-provider/methods/UpdateByTeam'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/identity-provider/methods/DeleteByTeam'
+        exec: []
+    inbound-ruleset:
+      id: heroku.misc.inbound-ruleset
+      name: inbound-ruleset
+      title: Inbound Ruleset
+      methods:
+        Current:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1inbound-ruleset/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Create:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1inbound-ruleset/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Info:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1inbound-rulesets~1{inbound_ruleset_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1inbound-rulesets/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/inbound-ruleset/methods/Current'
+        - $ref: '#/components/x-stackQL-resources/inbound-ruleset/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/inbound-ruleset/methods/List'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/inbound-ruleset/methods/Create'
+        update: []
+        delete: []
+        exec: []
+    invoice-address:
+      id: heroku.misc.invoice-address
+      name: invoice-address
+      title: Invoice Address
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1account~1invoice-address/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1account~1invoice-address/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/invoice-address/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/invoice-address/methods/Update'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    invoice:
+      id: heroku.misc.invoice
+      name: invoice
+      title: Invoice
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1account~1invoices~1{invoice_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1account~1invoices/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/invoice/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/invoice/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    password-reset:
+      id: heroku.misc.password-reset
+      name: password-reset
+      title: Password Reset
+      methods:
+        ResetPassword:
+          operation:
+            $ref: '#/paths/~1password-resets/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        CompleteResetPassword:
+          operation:
+            $ref: '#/paths/~1password-resets~1{password_reset_reset_password_token}~1actions~1finalize/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/password-reset/methods/ResetPassword'
+        - $ref: '#/components/x-stackQL-resources/password-reset/methods/CompleteResetPassword'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    peering-info:
+      id: heroku.misc.peering-info
+      name: peering-info
+      title: Peering Info
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1peering-info/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/peering-info/methods/Info'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    permission-entity:
+      id: heroku.misc.permission-entity
+      name: permission-entity
+      title: Permission Entity
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1permissions/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/permission-entity/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    pipeline-build:
+      id: heroku.misc.pipeline-build
+      name: pipeline-build
+      title: Pipeline Build
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1latest-builds/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/pipeline-build/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    pipeline-config-var:
+      id: heroku.misc.pipeline-config-var
+      name: pipeline-config-var
+      title: Pipeline Config Var
+      methods:
+        InfoForApp:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1stage~1{pipeline_coupling_stage}~1config-vars/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1stage~1{pipeline_coupling_stage}~1config-vars/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/pipeline-config-var/methods/InfoForApp'
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/pipeline-config-var/methods/Update'
+        delete: []
+        exec: []
+    pipeline-promotion-target:
+      id: heroku.misc.pipeline-promotion-target
+      name: pipeline-promotion-target
+      title: Pipeline Promotion Target
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1pipeline-promotions~1{pipeline_promotion_id}~1promotion-targets/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/pipeline-promotion-target/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    pipeline-stack:
+      id: heroku.misc.pipeline-stack
+      name: pipeline-stack
+      title: Pipeline Stack
+      methods:
+        DefaultStack:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1pipeline-stack/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/pipeline-stack/methods/DefaultStack'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    pipeline-transfer:
+      id: heroku.misc.pipeline-transfer
+      name: pipeline-transfer
+      title: Pipeline Transfer
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1pipeline-transfers/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+      sqlVerbs:
+        select: []
+        insert:
+        - $ref: '#/components/x-stackQL-resources/pipeline-transfer/methods/Create'
+        update: []
+        delete: []
+        exec: []
+    rate-limit:
+      id: heroku.misc.rate-limit
+      name: rate-limit
+      title: Rate Limit
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1account~1rate-limits/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/rate-limit/methods/Info'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    review-app:
+      id: heroku.misc.review-app
+      name: review-app
+      title: Review App
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1review-apps/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        GetReviewApp:
+          operation:
+            $ref: '#/paths/~1review-apps~1{review_app_id}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1review-apps~1{review_app_id}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        GetReviewAppByAppId:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1review-app/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1review-apps/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/review-app/methods/List'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/review-app/methods/Create'
+        update: []
+        delete:
+        - $ref: '#/components/x-stackQL-resources/review-app/methods/Delete'
+        exec:
+        - $ref: '#/components/x-stackQL-resources/review-app/methods/GetReviewApp'
+        - $ref: '#/components/x-stackQL-resources/review-app/methods/GetReviewAppByAppId'
+    review-app-config:
+      id: heroku.misc.review-app-config
+      name: review-app-config
+      title: Review App Config
+      methods:
+        Enable:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1review-app-config/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        Info:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1review-app-config/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1review-app-config/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1review-app-config/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/review-app-config/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/review-app-config/methods/Enable'
+        update:
+        - $ref: '#/components/x-stackQL-resources/review-app-config/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/review-app-config/methods/Delete'
+        exec: []
+    sms-number:
+      id: heroku.misc.sms-number
+      name: sms-number
+      title: Sms Number
+      methods:
+        SmsNumber:
+          operation:
+            $ref: '#/paths/~1users~1{account_identity}~1sms-number/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Recover:
+          operation:
+            $ref: '#/paths/~1users~1{account_identity}~1sms-number~1actions~1recover/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Confirm:
+          operation:
+            $ref: '#/paths/~1users~1{account_identity}~1sms-number~1actions~1confirm/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/sms-number/methods/SmsNumber'
+        - $ref: '#/components/x-stackQL-resources/sms-number/methods/Recover'
+        - $ref: '#/components/x-stackQL-resources/sms-number/methods/Confirm'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    source:
+      id: heroku.misc.source
+      name: source
+      title: Source
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1sources/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        CreateDeprecated:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1sources/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+      sqlVerbs:
+        select: []
+        insert:
+        - $ref: '#/components/x-stackQL-resources/source/methods/Create'
+        - $ref: '#/components/x-stackQL-resources/source/methods/CreateDeprecated'
+        update: []
+        delete: []
+        exec: []
+    space-app-access:
+      id: heroku.misc.space-app-access
+      name: space-app-access
+      title: Space App Access
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1members~1{account_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1members~1{account_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1members/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/space-app-access/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/space-app-access/methods/List'
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/space-app-access/methods/Update'
+        delete: []
+        exec: []
+    space-nat:
+      id: heroku.misc.space-nat
+      name: space-nat
+      title: Space Nat
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1nat/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/space-nat/methods/Info'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    space-topology:
+      id: heroku.misc.space-topology
+      name: space-topology
+      title: Space Topology
+      methods:
+        Topology:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1topology/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/space-topology/methods/Topology'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    space-transfer:
+      id: heroku.misc.space-transfer
+      name: space-transfer
+      title: Space Transfer
+      methods:
+        Transfer:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1transfer/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select: []
+        insert: []
+        update: []
+        delete: []
+        exec:
+        - $ref: '#/components/x-stackQL-resources/space-transfer/methods/Transfer'
+    team-add-on:
+      id: heroku.misc.team-add-on
+      name: team-add-on
+      title: Team Add On
+      methods:
+        ListForTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1addons/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-add-on/methods/ListForTeam'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    team-app-permission:
+      id: heroku.misc.team-app-permission
+      name: team-app-permission
+      title: Team App Permission
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1teams~1permissions/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-app-permission/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    team-daily-usage:
+      id: heroku.misc.team-daily-usage
+      name: team-daily-usage
+      title: Team Daily Usage
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1teams~1{team_id}~1usage~1daily/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-daily-usage/methods/Info'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    team-delinquency:
+      id: heroku.misc.team-delinquency
+      name: team-delinquency
+      title: Team Delinquency
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1delinquency/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-delinquency/methods/Info'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    team-invoice:
+      id: heroku.misc.team-invoice
+      name: team-invoice
+      title: Team Invoice
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1invoices~1{team_invoice_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1invoices/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-invoice/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/team-invoice/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    team-monthly-usage:
+      id: heroku.misc.team-monthly-usage
+      name: team-monthly-usage
+      title: Team Monthly Usage
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1teams~1{team_id}~1usage~1monthly/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-monthly-usage/methods/Info'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    team-preferences:
+      id: heroku.misc.team-preferences
+      name: team-preferences
+      title: Team Preferences
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1teams~1{team_preferences_identity}~1preferences/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1teams~1{team_preferences_identity}~1preferences/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-preferences/methods/List'
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/team-preferences/methods/Update'
+        delete: []
+        exec: []
+    team-space:
+      id: heroku.misc.team-space
+      name: team-space
+      title: Team Space
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1spaces/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-space/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    telemetry-drain:
+      id: heroku.misc.telemetry-drain
+      name: telemetry-drain
+      title: Telemetry Drain
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1telemetry-drains/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        ListByApp:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1telemetry-drains/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListBySpace:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1telemetry-drains/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1telemetry-drains~1{telemetry_drain_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1telemetry-drains~1{telemetry_drain_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1telemetry-drains~1{telemetry_drain_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/telemetry-drain/methods/ListByApp'
+        - $ref: '#/components/x-stackQL-resources/telemetry-drain/methods/ListBySpace'
+        - $ref: '#/components/x-stackQL-resources/telemetry-drain/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/telemetry-drain/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/telemetry-drain/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/telemetry-drain/methods/Delete'
+        exec: []
+    test-case:
+      id: heroku.misc.test-case
+      name: test-case
+      title: Test Case
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1test-runs~1{test_run_id}~1test-cases/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/test-case/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    test-node:
+      id: heroku.misc.test-node
+      name: test-node
+      title: Test Node
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1test-runs~1{test_run_identity}~1test-nodes/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/test-node/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    test-run:
+      id: heroku.misc.test-run
+      name: test-run
+      title: Test Run
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1test-runs/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        Info:
+          operation:
+            $ref: '#/paths/~1test-runs~1{test_run_id}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1test-runs/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        InfoByPipeline:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1test-runs~1{test_run_number}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1test-runs~1{test_run_number}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/test-run/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/test-run/methods/List'
+        - $ref: '#/components/x-stackQL-resources/test-run/methods/InfoByPipeline'
+        - $ref: '#/components/x-stackQL-resources/test-run/methods/Update'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/test-run/methods/Create'
+        update: []
+        delete: []
+        exec: []
+    user-preferences:
+      id: heroku.misc.user-preferences
+      name: user-preferences
+      title: User Preferences
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1users~1{user_preferences_identity}~1preferences/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1users~1{user_preferences_identity}~1preferences/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/user-preferences/methods/List'
+        insert: []
+        update:
+        - $ref: '#/components/x-stackQL-resources/user-preferences/methods/Update'
+        delete: []
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/networking.yaml
+++ b/provider/heroku/v0/services/networking.yaml
@@ -1,0 +1,552 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Networking
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /spaces/{space_identity}/peerings:
+    get:
+      summary: List
+      description: List peering connections of a private space.
+      operationId: peeringList
+      tags:
+      - networking
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/peering'
+                type:
+                - array
+      x-stackQL-resource: peering
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /spaces/{space_identity}/peerings/{peering_pcx_id}/actions/accept:
+    post:
+      summary: Accept
+      description: Accept a pending peering connection with a private space.
+      operationId: peeringAccept
+      tags:
+      - networking
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      - name: peering_pcx_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for pcx_id of peering.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/peering'
+      x-stackQL-resource: peering
+      x-stackQL-method: Accept
+      x-stackQL-verb: exec
+  /spaces/{space_identity}/peerings/{peering_pcx_id}:
+    delete:
+      summary: Destroy
+      description: Destroy an active peering connection with a private space.
+      operationId: peeringDestroy
+      tags:
+      - networking
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      - name: peering_pcx_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for pcx_id of peering.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: peering
+      x-stackQL-method: Destroy
+      x-stackQL-verb: exec
+    get:
+      summary: Info
+      description: Fetch information for existing peering connection
+      operationId: peeringInfo
+      tags:
+      - networking
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      - name: peering_pcx_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for pcx_id of peering.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/peering'
+      x-stackQL-resource: peering
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /spaces/{space_identity}/vpn-connections:
+    post:
+      summary: Create
+      description: Create a new VPN connection in a private space.
+      operationId: vpn_connectionCreate
+      tags:
+      - networking
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/vpn-connection'
+      x-stackQL-resource: vpn-connection
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+                public_ip:
+                  $ref: '#/components/schemas/public_ip'
+                routable_cidrs:
+                  $ref: '#/components/schemas/routable_cidrs'
+              required:
+              - name
+              - public_ip
+              - routable_cidrs
+              type:
+              - object
+    get:
+      summary: List
+      description: List VPN connections for a space.
+      operationId: vpn_connectionList
+      tags:
+      - networking
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/vpn-connection'
+                type:
+                - array
+      x-stackQL-resource: vpn-connection
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /spaces/{space_identity}/vpn-connections/{vpn_connection_identity}:
+    delete:
+      summary: Destroy
+      description: Destroy existing VPN Connection
+      operationId: vpn_connectionDestroy
+      tags:
+      - networking
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      - name: vpn_connection_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of vpn-connection.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: vpn-connection
+      x-stackQL-method: Destroy
+      x-stackQL-verb: exec
+    get:
+      summary: Info
+      description: Info for an existing vpn-connection.
+      operationId: vpn_connectionInfo
+      tags:
+      - networking
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      - name: vpn_connection_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of vpn-connection.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/vpn-connection'
+      x-stackQL-resource: vpn-connection
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update a VPN connection in a private space.
+      operationId: vpn_connectionUpdate
+      tags:
+      - networking
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      - name: vpn_connection_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of vpn-connection.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/vpn-connection'
+      x-stackQL-resource: vpn-connection
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                routable_cidrs:
+                  $ref: '#/components/schemas/routable_cidrs'
+              required:
+              - routable_cidrs
+              type:
+              - object
+components:
+  schemas:
+    peering:
+      description: '[Peering](https://devcenter.heroku.com/articles/private-space-peering) provides a way to peer your Private
+        Space VPC to another AWS VPC.'
+      type:
+      - object
+      properties:
+        type:
+          $ref: '#/components/schemas/type'
+        pcx_id:
+          $ref: '#/components/schemas/pcx_id'
+        cidr_blocks:
+          description: The CIDR blocks of the peer.
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/cidr'
+        status:
+          $ref: '#/components/schemas/status'
+        aws_vpc_id:
+          $ref: '#/components/schemas/vpc_id'
+        aws_region:
+          $ref: '#/components/schemas/aws_region'
+        aws_account_id:
+          $ref: '#/components/schemas/aws_account_id'
+        expires:
+          $ref: '#/components/schemas/expires'
+    type:
+      description: The type of peering connection.
+      type:
+      - string
+      enum:
+      - heroku-managed
+      - customer-managed
+      - unknown
+    pcx_id:
+      description: The AWS VPC Peering Connection ID of the peering.
+      readOnly: true
+      type:
+      - string
+    cidr:
+      description: An IP address and the number of significant bits that make up the routing or networking portion.
+      type:
+      - string
+    status:
+      description: The status of the peering connection.
+      enum:
+      - initiating-request
+      - pending-acceptance
+      - provisioning
+      - active
+      - failed
+      - expired
+      - rejected
+      - deleted
+      type:
+      - string
+      readOnly: true
+    vpc_id:
+      description: The AWS VPC ID of the peer.
+      readOnly: true
+      type:
+      - string
+    aws_region:
+      description: The AWS region of the peer connection.
+      readOnly: true
+      type:
+      - string
+    aws_account_id:
+      description: The AWS account ID of your Private Space.
+      readOnly: true
+      type:
+      - string
+    expires:
+      description: When a peering connection will expire.
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    vpn-connection:
+      description: '[VPN](https://devcenter.heroku.com/articles/private-space-vpn-connection) provides a way to connect your
+        Private Spaces to your network via VPN.'
+      type:
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        public_ip:
+          $ref: '#/components/schemas/public_ip'
+        routable_cidrs:
+          $ref: '#/components/schemas/routable_cidrs'
+        space_cidr_block:
+          $ref: '#/components/schemas/space_cidr_block'
+        tunnels:
+          items:
+            $ref: '#/components/schemas/tunnel'
+          type:
+          - array
+        ike_version:
+          $ref: '#/components/schemas/ike_version'
+        status:
+          $ref: '#/components/schemas/status'
+        status_message:
+          $ref: '#/components/schemas/status_message'
+    id:
+      description: VPN ID
+      readOnly: true
+      type:
+      - string
+    name:
+      description: VPN Name
+      type:
+      - string
+    public_ip:
+      description: Public IP of VPN customer gateway
+      type:
+      - string
+    routable_cidrs:
+      description: Routable CIDRs of VPN
+      type:
+      - array
+      items:
+        type:
+        - string
+    space_cidr_block:
+      description: CIDR Block of the Private Space
+      readOnly: true
+      type:
+      - string
+    tunnel:
+      description: Tunnel info
+      readOnly: true
+      type:
+      - object
+      properties:
+        last_status_change:
+          description: Timestamp of last status changed
+          type:
+          - string
+        ip:
+          description: Public IP address for the tunnel
+          type:
+          - string
+        customer_ip:
+          description: Public IP address for the customer side of the tunnel
+          type:
+          - string
+        pre_shared_key:
+          description: Pre-shared key
+          type:
+          - string
+        status:
+          description: Status of the tunnel
+          enum:
+          - UP
+          - DOWN
+          type:
+          - string
+        status_message:
+          description: Details of the status
+          type:
+          - string
+    ike_version:
+      description: IKE Version
+      readOnly: true
+      type:
+      - integer
+    status_message:
+      description: Details of the status
+      readOnly: true
+      type:
+      - string
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    peering:
+      id: heroku.networking.peering
+      name: peering
+      title: Peering
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1peerings/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Accept:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1peerings~1{peering_pcx_id}~1actions~1accept/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Destroy:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1peerings~1{peering_pcx_id}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1peerings~1{peering_pcx_id}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/peering/methods/List'
+        - $ref: '#/components/x-stackQL-resources/peering/methods/Info'
+        insert: []
+        update: []
+        delete: []
+        exec:
+        - $ref: '#/components/x-stackQL-resources/peering/methods/Accept'
+        - $ref: '#/components/x-stackQL-resources/peering/methods/Destroy'
+    vpn-connection:
+      id: heroku.networking.vpn-connection
+      name: vpn-connection
+      title: Vpn Connection
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1vpn-connections/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1vpn-connections/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Destroy:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1vpn-connections~1{vpn_connection_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1vpn-connections~1{vpn_connection_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}~1vpn-connections~1{vpn_connection_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/vpn-connection/methods/List'
+        - $ref: '#/components/x-stackQL-resources/vpn-connection/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/vpn-connection/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/vpn-connection/methods/Update'
+        delete: []
+        exec:
+        - $ref: '#/components/x-stackQL-resources/vpn-connection/methods/Destroy'
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/oauth.yaml
+++ b/provider/heroku/v0/services/oauth.yaml
@@ -1,0 +1,794 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Oauth
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /oauth/authorizations:
+    post:
+      summary: Create
+      description: Create a new OAuth authorization.
+      operationId: oauth_authorizationCreate
+      tags:
+      - oauth
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/oauth-authorization'
+      x-stackQL-resource: oauth-authorization
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                client:
+                  $ref: '#/components/schemas/identity'
+                description:
+                  $ref: '#/components/schemas/description'
+                expires_in:
+                  $ref: '#/components/schemas/expires_in'
+                scope:
+                  $ref: '#/components/schemas/scope'
+              required:
+              - scope
+              type:
+              - object
+    get:
+      summary: List
+      description: List OAuth authorizations.
+      operationId: oauth_authorizationList
+      tags:
+      - oauth
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/oauth-authorization'
+                type:
+                - array
+      x-stackQL-resource: oauth-authorization
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /oauth/authorizations/{oauth_authorization_identity}:
+    delete:
+      summary: Delete
+      description: Delete OAuth authorization.
+      operationId: oauth_authorizationDelete
+      tags:
+      - oauth
+      parameters:
+      - name: oauth_authorization_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of oauth-authorization.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: oauth-authorization
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Info for an OAuth authorization.
+      operationId: oauth_authorizationInfo
+      tags:
+      - oauth
+      parameters:
+      - name: oauth_authorization_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of oauth-authorization.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/oauth-authorization'
+      x-stackQL-resource: oauth-authorization
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update an existing OAuth authorization.
+      operationId: oauth_authorizationUpdate
+      tags:
+      - oauth
+      parameters:
+      - name: oauth_authorization_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of oauth-authorization.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/oauth-authorization'
+      x-stackQL-resource: oauth-authorization
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                description:
+                  $ref: '#/components/schemas/description'
+                client:
+                  type:
+                  - object
+                  description: identifier of the client that obtained this authorization
+                  properties:
+                    id:
+                      $ref: '#/components/schemas/id'
+                    secret:
+                      $ref: '#/components/schemas/secret'
+              required:
+              - client
+              type:
+              - object
+  /oauth/authorizations/{oauth_authorization_identity}/actions/regenerate-tokens:
+    post:
+      summary: Regenerate
+      description: Regenerate OAuth tokens. This endpoint is only available to direct authorizations or privileged OAuth clients.
+      operationId: oauth_authorizationRegenerate
+      tags:
+      - oauth
+      parameters:
+      - name: oauth_authorization_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of oauth-authorization.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/oauth-authorization'
+      x-stackQL-resource: oauth-authorization
+      x-stackQL-method: Regenerate
+      x-stackQL-verb: update
+  /oauth/clients:
+    post:
+      summary: Create
+      description: Create a new OAuth client.
+      operationId: oauth_clientCreate
+      tags:
+      - oauth
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/oauth-client'
+      x-stackQL-resource: oauth-client
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+                redirect_uri:
+                  $ref: '#/components/schemas/redirect_uri'
+              required:
+              - name
+              - redirect_uri
+              type:
+              - object
+    get:
+      summary: List
+      description: List OAuth clients
+      operationId: oauth_clientList
+      tags:
+      - oauth
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/oauth-client'
+                type:
+                - array
+      x-stackQL-resource: oauth-client
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /oauth/clients/{oauth_client_identity}:
+    delete:
+      summary: Delete
+      description: Delete OAuth client.
+      operationId: oauth_clientDelete
+      tags:
+      - oauth
+      parameters:
+      - name: oauth_client_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of oauth-client.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: oauth-client
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    get:
+      summary: Info
+      description: Info for an OAuth client. The output for unauthenticated requests excludes the `secret` parameter.
+      operationId: oauth_clientInfo
+      tags:
+      - oauth
+      parameters:
+      - name: oauth_client_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of oauth-client.
+      responses:
+        '200':
+          description: Successful operation
+      x-stackQL-resource: oauth-client
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update OAuth client
+      operationId: oauth_clientUpdate
+      tags:
+      - oauth
+      parameters:
+      - name: oauth_client_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of oauth-client.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/oauth-client'
+      x-stackQL-resource: oauth-client
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+                redirect_uri:
+                  $ref: '#/components/schemas/redirect_uri'
+              type:
+              - object
+  /oauth/clients/{oauth_client_identity}/actions/rotate-credentials:
+    post:
+      summary: Rotate Credentials
+      description: Rotate credentials for an OAuth client
+      operationId: oauth_clientRotateCredentials
+      tags:
+      - oauth
+      parameters:
+      - name: oauth_client_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of oauth-client.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/oauth-client'
+      x-stackQL-resource: oauth-client
+      x-stackQL-method: RotateCredentials
+      x-stackQL-verb: update
+  /oauth/tokens:
+    post:
+      summary: Create
+      description: Create a new OAuth token.
+      operationId: oauth_tokenCreate
+      tags:
+      - oauth
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/oauth-token'
+      x-stackQL-resource: oauth-token
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                client:
+                  type:
+                  - object
+                  properties:
+                    secret:
+                      $ref: '#/components/schemas/secret'
+                grant:
+                  type:
+                  - object
+                  properties:
+                    code:
+                      $ref: '#/components/schemas/code'
+                    type:
+                      $ref: '#/components/schemas/type'
+                refresh_token:
+                  type:
+                  - object
+                  properties:
+                    token:
+                      $ref: '#/components/schemas/token'
+              required:
+              - grant
+              - client
+              - refresh_token
+              type:
+              - object
+  /oauth/tokens/{oauth_token_identity}:
+    delete:
+      summary: Delete
+      description: Revoke OAuth access token.
+      operationId: oauth_tokenDelete
+      tags:
+      - oauth
+      parameters:
+      - name: oauth_token_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of oauth-token.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: oauth-token
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+components:
+  schemas:
+    oauth-authorization:
+      description: OAuth authorizations represent clients that a Heroku user has authorized to automate, customize or extend
+        their usage of the platform. For more information please refer to the [Heroku OAuth documentation](https://devcenter.heroku.com/articles/oauth)
+      type:
+      - object
+      properties:
+        access_token:
+          description: access token for this authorization
+          properties:
+            expires_in:
+              $ref: '#/components/schemas/expires_in'
+            id:
+              $ref: '#/components/schemas/id'
+            token:
+              $ref: '#/components/schemas/token'
+          type:
+          - 'null'
+          - object
+        client:
+          description: identifier of the client that obtained this authorization, if any
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+            redirect_uri:
+              $ref: '#/components/schemas/redirect_uri'
+          type:
+          - 'null'
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        description:
+          $ref: '#/components/schemas/description'
+        grant:
+          description: this authorization's grant
+          properties:
+            code:
+              $ref: '#/components/schemas/code'
+            expires_in:
+              $ref: '#/components/schemas/expires_in'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - 'null'
+          - object
+        id:
+          $ref: '#/components/schemas/id'
+        refresh_token:
+          description: refresh token for this authorization
+          properties:
+            expires_in:
+              $ref: '#/components/schemas/expires_in'
+            id:
+              $ref: '#/components/schemas/id'
+            token:
+              $ref: '#/components/schemas/token'
+          type:
+          - 'null'
+          - object
+        scope:
+          $ref: '#/components/schemas/scope'
+        session:
+          description: this authorization's session
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - 'null'
+          - object
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        user:
+          description: authenticated user associated with this authorization
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            email:
+              $ref: '#/components/schemas/email'
+            full_name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+    expires_in:
+      description: seconds until OAuth token expires; may be `null` for tokens with indefinite lifetime
+      readOnly: true
+      type:
+      - 'null'
+      - integer
+    id:
+      description: unique identifier of OAuth token
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    token:
+      description: contents of the token to be used for authorization
+      readOnly: true
+      type:
+      - string
+    name:
+      description: OAuth client name
+      readOnly: true
+      type:
+      - string
+    redirect_uri:
+      description: endpoint for redirection after authorization with OAuth client
+      readOnly: true
+      type:
+      - string
+    created_at:
+      description: when OAuth authorization was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    description:
+      description: human-friendly description of this OAuth authorization
+      readOnly: true
+      type:
+      - string
+    code:
+      description: grant code received from OAuth web application authorization
+      readOnly: true
+      type:
+      - string
+    scope:
+      description: The scope of access OAuth authorization allows
+      readOnly: true
+      type:
+      - array
+      items:
+        type:
+        - string
+    updated_at:
+      description: when OAuth authorization was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    email:
+      description: unique email address of account
+      format: email
+      readOnly: false
+      type:
+      - string
+    identity:
+      anyOf:
+      - $ref: '#/components/schemas/id'
+    secret:
+      description: secret used to obtain OAuth authorizations under this client
+      readOnly: true
+      type:
+      - string
+    oauth-client:
+      description: OAuth clients are applications that Heroku users can authorize to automate, customize or extend their usage
+        of the platform. For more information please refer to the [Heroku OAuth documentation](https://devcenter.heroku.com/articles/oauth).
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        ignores_delinquent:
+          $ref: '#/components/schemas/ignores_delinquent'
+        name:
+          $ref: '#/components/schemas/name'
+        redirect_uri:
+          $ref: '#/components/schemas/redirect_uri'
+        secret:
+          $ref: '#/components/schemas/secret'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    ignores_delinquent:
+      description: whether the client is still operable given a delinquent account
+      readOnly: true
+      type:
+      - boolean
+      - 'null'
+    oauth-token:
+      description: OAuth tokens provide access for authorized clients to act on behalf of a Heroku user to automate, customize
+        or extend their usage of the platform. For more information please refer to the [Heroku OAuth documentation](https://devcenter.heroku.com/articles/oauth)
+      type:
+      - object
+      properties:
+        access_token:
+          description: current access token
+          properties:
+            expires_in:
+              $ref: '#/components/schemas/expires_in'
+            id:
+              $ref: '#/components/schemas/id'
+            token:
+              $ref: '#/components/schemas/token'
+          type:
+          - object
+        authorization:
+          description: authorization for this set of tokens
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        client:
+          description: OAuth client secret used to obtain token
+          properties:
+            secret:
+              $ref: '#/components/schemas/secret'
+          type:
+          - 'null'
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        grant:
+          description: grant used on the underlying authorization
+          properties:
+            code:
+              $ref: '#/components/schemas/code'
+            type:
+              $ref: '#/components/schemas/type'
+          type:
+          - object
+        id:
+          $ref: '#/components/schemas/id'
+        refresh_token:
+          description: refresh token for this authorization
+          properties:
+            expires_in:
+              $ref: '#/components/schemas/expires_in'
+            id:
+              $ref: '#/components/schemas/id'
+            token:
+              $ref: '#/components/schemas/token'
+          type:
+          - object
+        session:
+          description: OAuth session using this token
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        user:
+          description: Reference to the user associated with this token
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+    type:
+      description: type of grant requested, one of `authorization_code` or `refresh_token`
+      readOnly: false
+      type:
+      - string
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    oauth-authorization:
+      id: heroku.oauth.oauth-authorization
+      name: oauth-authorization
+      title: Oauth Authorization
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1oauth~1authorizations/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1oauth~1authorizations/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1oauth~1authorizations~1{oauth_authorization_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1oauth~1authorizations~1{oauth_authorization_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1oauth~1authorizations~1{oauth_authorization_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Regenerate:
+          operation:
+            $ref: '#/paths/~1oauth~1authorizations~1{oauth_authorization_identity}~1actions~1regenerate-tokens/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/oauth-authorization/methods/List'
+        - $ref: '#/components/x-stackQL-resources/oauth-authorization/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/oauth-authorization/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/oauth-authorization/methods/Update'
+        - $ref: '#/components/x-stackQL-resources/oauth-authorization/methods/Regenerate'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/oauth-authorization/methods/Delete'
+        exec: []
+    oauth-client:
+      id: heroku.oauth.oauth-client
+      name: oauth-client
+      title: Oauth Client
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1oauth~1clients/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1oauth~1clients/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1oauth~1clients~1{oauth_client_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Info:
+          operation:
+            $ref: '#/paths/~1oauth~1clients~1{oauth_client_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1oauth~1clients~1{oauth_client_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        RotateCredentials:
+          operation:
+            $ref: '#/paths/~1oauth~1clients~1{oauth_client_identity}~1actions~1rotate-credentials/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/oauth-client/methods/List'
+        - $ref: '#/components/x-stackQL-resources/oauth-client/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/oauth-client/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/oauth-client/methods/Update'
+        - $ref: '#/components/x-stackQL-resources/oauth-client/methods/RotateCredentials'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/oauth-client/methods/Delete'
+        exec: []
+    oauth-token:
+      id: heroku.oauth.oauth-token
+      name: oauth-token
+      title: Oauth Token
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1oauth~1tokens/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        Delete:
+          operation:
+            $ref: '#/paths/~1oauth~1tokens~1{oauth_token_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+      sqlVerbs:
+        select: []
+        insert:
+        - $ref: '#/components/x-stackQL-resources/oauth-token/methods/Create'
+        update: []
+        delete:
+        - $ref: '#/components/x-stackQL-resources/oauth-token/methods/Delete'
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/pipelines.yaml
+++ b/provider/heroku/v0/services/pipelines.yaml
@@ -1,0 +1,921 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Pipelines
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /pipelines/{pipeline_id}/pipeline-couplings:
+    get:
+      summary: List By Pipeline
+      description: List couplings for a pipeline
+      operationId: pipeline_couplingListByPipeline
+      tags:
+      - pipelines
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/pipeline-coupling'
+                type:
+                - array
+      x-stackQL-resource: pipeline-coupling
+      x-stackQL-method: ListByPipeline
+      x-stackQL-verb: select
+  /users/~/pipeline-couplings:
+    get:
+      summary: List By Current User
+      description: List pipeline couplings for the current user.
+      operationId: pipeline_couplingListByCurrentUser
+      tags:
+      - pipelines
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/pipeline-coupling'
+                type:
+                - array
+      x-stackQL-resource: pipeline-coupling
+      x-stackQL-method: ListByCurrentUser
+      x-stackQL-verb: select
+  /pipeline-couplings:
+    get:
+      summary: List
+      description: List pipeline couplings.
+      operationId: pipeline_couplingList
+      tags:
+      - pipelines
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/pipeline-coupling'
+                type:
+                - array
+      x-stackQL-resource: pipeline-coupling
+      x-stackQL-method: List
+      x-stackQL-verb: select
+    post:
+      summary: Create
+      description: Create a new pipeline coupling.
+      operationId: pipeline_couplingCreate
+      tags:
+      - pipelines
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pipeline-coupling'
+      x-stackQL-resource: pipeline-coupling
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                app:
+                  $ref: '#/components/schemas/identity'
+                pipeline:
+                  $ref: '#/components/schemas/id'
+                stage:
+                  $ref: '#/components/schemas/stage'
+              required:
+              - app
+              - pipeline
+              - stage
+              type:
+              - object
+  /teams/{team_identity}/pipeline-couplings:
+    get:
+      summary: List By Team
+      description: List pipeline couplings for a team.
+      operationId: pipeline_couplingListByTeam
+      tags:
+      - pipelines
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/pipeline-coupling'
+                type:
+                - array
+      x-stackQL-resource: pipeline-coupling
+      x-stackQL-method: ListByTeam
+      x-stackQL-verb: select
+  /pipeline-couplings/{pipeline_coupling_identity}:
+    get:
+      summary: Info
+      description: Info for an existing pipeline coupling.
+      operationId: pipeline_couplingInfo
+      tags:
+      - pipelines
+      parameters:
+      - name: pipeline_coupling_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of pipeline-coupling.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pipeline-coupling'
+      x-stackQL-resource: pipeline-coupling
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    delete:
+      summary: Delete
+      description: Delete an existing pipeline coupling.
+      operationId: pipeline_couplingDelete
+      tags:
+      - pipelines
+      parameters:
+      - name: pipeline_coupling_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of pipeline-coupling.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: pipeline-coupling
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    patch:
+      summary: Update
+      description: Update an existing pipeline coupling.
+      operationId: pipeline_couplingUpdate
+      tags:
+      - pipelines
+      parameters:
+      - name: pipeline_coupling_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of pipeline-coupling.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pipeline-coupling'
+      x-stackQL-resource: pipeline-coupling
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                stage:
+                  $ref: '#/components/schemas/stage'
+              type:
+              - object
+  /apps/{app_identity}/pipeline-couplings:
+    get:
+      summary: Info By App
+      description: Info for an existing pipeline coupling.
+      operationId: pipeline_couplingInfoByApp
+      tags:
+      - pipelines
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pipeline-coupling'
+      x-stackQL-resource: pipeline-coupling
+      x-stackQL-method: InfoByApp
+      x-stackQL-verb: select
+  /pipelines/{pipeline_id}/latest-deployments:
+    get:
+      summary: List
+      description: List latest deployments for each app in a pipeline. A deployment is a release that changed your source
+        slug, container image, or Heroku processes.
+      operationId: pipeline_deploymentList
+      tags:
+      - pipelines
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/release'
+                type:
+                - array
+      x-stackQL-resource: pipeline-deployment
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /pipeline-promotions:
+    post:
+      summary: Create
+      description: Create a new promotion.
+      operationId: pipeline_promotionCreate
+      tags:
+      - pipelines
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pipeline-promotion'
+      x-stackQL-resource: pipeline-promotion
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                pipeline:
+                  description: pipeline involved in the promotion
+                  properties:
+                    id:
+                      $ref: '#/components/schemas/id'
+                  required:
+                  - id
+                  type:
+                  - object
+                source:
+                  description: the app being promoted from
+                  properties:
+                    app:
+                      description: the app which was promoted from
+                      properties:
+                        id:
+                          $ref: '#/components/schemas/id'
+                      strictProperties: true
+                      type:
+                      - object
+                  type:
+                  - object
+                targets:
+                  items:
+                    properties:
+                      app:
+                        description: the app is being promoted to
+                        properties:
+                          id:
+                            $ref: '#/components/schemas/id'
+                        strictProperties: true
+                        type:
+                        - object
+                    type:
+                    - object
+                  type:
+                  - array
+              required:
+              - pipeline
+              - source
+              - targets
+              type:
+              - object
+  /pipeline-promotions/{pipeline_promotion_identity}:
+    get:
+      summary: Info
+      description: Info for existing pipeline promotion.
+      operationId: pipeline_promotionInfo
+      tags:
+      - pipelines
+      parameters:
+      - name: pipeline_promotion_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of pipeline-promotion.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pipeline-promotion'
+      x-stackQL-resource: pipeline-promotion
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /pipelines/{pipeline_id}/latest-releases:
+    get:
+      summary: List
+      description: List latest releases for each app in a pipeline
+      operationId: pipeline_releaseList
+      tags:
+      - pipelines
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/release'
+                type:
+                - array
+      x-stackQL-resource: pipeline-release
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /pipelines:
+    post:
+      summary: Create
+      description: Create a new pipeline.
+      operationId: pipelineCreate
+      tags:
+      - pipelines
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pipeline'
+      x-stackQL-resource: pipeline
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+                owner:
+                  description: Pipeline owner
+                  $ref: '#/components/schemas/owner'
+                  type:
+                  - object
+                  - 'null'
+              required:
+              - name
+              type:
+              - object
+    get:
+      summary: List
+      description: List existing pipelines.
+      operationId: pipelineList
+      tags:
+      - pipelines
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/pipeline'
+                type:
+                - array
+      x-stackQL-resource: pipeline
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /pipelines/{pipeline_identity}:
+    get:
+      summary: Info
+      description: Info for existing pipeline.
+      operationId: pipelineInfo
+      tags:
+      - pipelines
+      parameters:
+      - name: pipeline_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of pipeline.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pipeline'
+      x-stackQL-resource: pipeline
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /pipelines/{pipeline_id}:
+    delete:
+      summary: Delete
+      description: Delete an existing pipeline.
+      operationId: pipelineDelete
+      tags:
+      - pipelines
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: pipeline
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+    patch:
+      summary: Update
+      description: Update an existing pipeline.
+      operationId: pipelineUpdate
+      tags:
+      - pipelines
+      parameters:
+      - name: pipeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for id of pipeline.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pipeline'
+      x-stackQL-resource: pipeline
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+              type:
+              - object
+components:
+  schemas:
+    pipeline-coupling:
+      description: Information about an app's coupling to a pipeline
+      type:
+      - object
+      properties:
+        app:
+          description: app involved in the pipeline coupling
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        pipeline:
+          description: pipeline involved in the coupling
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        stage:
+          $ref: '#/components/schemas/stage'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    id:
+      description: unique identifier of app
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    created_at:
+      description: when pipeline coupling was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    stage:
+      description: target pipeline stage
+      enum:
+      - test
+      - review
+      - development
+      - staging
+      - production
+      type:
+      - string
+    updated_at:
+      description: when pipeline coupling was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    identity:
+      anyOf:
+      - $ref: '#/components/schemas/id'
+      - $ref: '#/components/schemas/name'
+    release:
+      description: A release represents a combination of code, config vars and add-ons for an app on Heroku.
+      type:
+      - object
+      properties:
+        addon_plan_names:
+          description: add-on plans installed on the app for this release
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/name'
+        artifacts:
+          description: build artifacts for the release
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/artifact'
+        app:
+          description: app involved in the release
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        description:
+          $ref: '#/components/schemas/description'
+        id:
+          $ref: '#/components/schemas/id'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        slug:
+          description: slug running in this release
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+          - 'null'
+        status:
+          $ref: '#/components/schemas/status'
+        user:
+          description: user that created the release
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            email:
+              $ref: '#/components/schemas/email'
+          type:
+          - object
+        version:
+          $ref: '#/components/schemas/version'
+        current:
+          $ref: '#/components/schemas/current'
+        output_stream_url:
+          $ref: '#/components/schemas/output_stream_url'
+        eligible_for_rollback:
+          $ref: '#/components/schemas/eligible_for_rollback'
+    pipeline-promotion:
+      description: Promotions allow you to move code from an app in a pipeline to all targets
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        pipeline:
+          description: the pipeline which the promotion belongs to
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        source:
+          description: the app being promoted from
+          properties:
+            app:
+              description: the app which was promoted from
+              properties:
+                id:
+                  $ref: '#/components/schemas/id'
+              type:
+              - object
+            release:
+              description: the release used to promoted from
+              properties:
+                id:
+                  $ref: '#/components/schemas/id'
+              type:
+              - object
+          type:
+          - object
+        status:
+          $ref: '#/components/schemas/status'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    status:
+      description: status of promotion
+      readOnly: true
+      enum:
+      - pending
+      - completed
+      type:
+      - string
+    pipeline:
+      description: A pipeline allows grouping of apps into different stages.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        owner:
+          $ref: '#/components/schemas/owner'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        generation:
+          $ref: '#/components/schemas/generation'
+    name:
+      description: name of pipeline
+      pattern: ^[a-z][a-z0-9-]{2,29}$
+      readOnly: false
+      type:
+      - string
+    owner:
+      description: Owner of a pipeline.
+      properties:
+        id:
+          $ref: '#/components/schemas/owner'
+        type:
+          $ref: '#/components/schemas/owner'
+      required:
+      - id
+      - type
+      type:
+      - object
+      - 'null'
+    generation:
+      description: the generation of the Heroku platform for this pipeline
+      properties:
+        id:
+          $ref: '#/components/schemas/generation'
+        name:
+          $ref: '#/components/schemas/generation'
+      type:
+      - object
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    pipeline-coupling:
+      id: heroku.pipelines.pipeline-coupling
+      name: pipeline-coupling
+      title: Pipeline Coupling
+      methods:
+        ListByPipeline:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1pipeline-couplings/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByCurrentUser:
+          operation:
+            $ref: '#/paths/~1users~1~~1pipeline-couplings/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1pipeline-couplings/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Create:
+          operation:
+            $ref: '#/paths/~1pipeline-couplings/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        ListByTeam:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1pipeline-couplings/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Info:
+          operation:
+            $ref: '#/paths/~1pipeline-couplings~1{pipeline_coupling_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1pipeline-couplings~1{pipeline_coupling_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Update:
+          operation:
+            $ref: '#/paths/~1pipeline-couplings~1{pipeline_coupling_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        InfoByApp:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1pipeline-couplings/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/pipeline-coupling/methods/ListByPipeline'
+        - $ref: '#/components/x-stackQL-resources/pipeline-coupling/methods/ListByCurrentUser'
+        - $ref: '#/components/x-stackQL-resources/pipeline-coupling/methods/List'
+        - $ref: '#/components/x-stackQL-resources/pipeline-coupling/methods/ListByTeam'
+        - $ref: '#/components/x-stackQL-resources/pipeline-coupling/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/pipeline-coupling/methods/InfoByApp'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/pipeline-coupling/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/pipeline-coupling/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/pipeline-coupling/methods/Delete'
+        exec: []
+    pipeline-deployment:
+      id: heroku.pipelines.pipeline-deployment
+      name: pipeline-deployment
+      title: Pipeline Deployment
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1latest-deployments/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/pipeline-deployment/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    pipeline-promotion:
+      id: heroku.pipelines.pipeline-promotion
+      name: pipeline-promotion
+      title: Pipeline Promotion
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1pipeline-promotions/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        Info:
+          operation:
+            $ref: '#/paths/~1pipeline-promotions~1{pipeline_promotion_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/pipeline-promotion/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/pipeline-promotion/methods/Create'
+        update: []
+        delete: []
+        exec: []
+    pipeline-release:
+      id: heroku.pipelines.pipeline-release
+      name: pipeline-release
+      title: Pipeline Release
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}~1latest-releases/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/pipeline-release/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    pipeline:
+      id: heroku.pipelines.pipeline
+      name: pipeline
+      title: Pipeline
+      methods:
+        Create:
+          operation:
+            $ref: '#/paths/~1pipelines/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        List:
+          operation:
+            $ref: '#/paths/~1pipelines/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Info:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Update:
+          operation:
+            $ref: '#/paths/~1pipelines~1{pipeline_id}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/pipeline/methods/List'
+        - $ref: '#/components/x-stackQL-resources/pipeline/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/pipeline/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/pipeline/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/pipeline/methods/Delete'
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/platform.yaml
+++ b/provider/heroku/v0/services/platform.yaml
@@ -1,0 +1,265 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Platform
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /regions/{region_identity}:
+    get:
+      summary: Info
+      description: Info for existing region.
+      operationId: regionInfo
+      tags:
+      - platform
+      parameters:
+      - name: region_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of region.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/region'
+      x-stackQL-resource: region
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /regions:
+    get:
+      summary: List
+      description: List existing regions.
+      operationId: regionList
+      tags:
+      - platform
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/region'
+                type:
+                - array
+      x-stackQL-resource: region
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /stacks/{stack_identity}:
+    get:
+      summary: Info
+      description: Stack info.
+      operationId: stackInfo
+      tags:
+      - platform
+      parameters:
+      - name: stack_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of stack.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/stack'
+      x-stackQL-resource: stack
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /stacks:
+    get:
+      summary: List
+      description: List available stacks.
+      operationId: stackList
+      tags:
+      - platform
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/stack'
+                type:
+                - array
+      x-stackQL-resource: stack
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /apps/{app_identity}/available-stacks:
+    get:
+      summary: List by App
+      description: List available app stacks for an app.
+      operationId: stackListByApp
+      tags:
+      - platform
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/stack'
+                type:
+                - array
+      x-stackQL-resource: stack
+      x-stackQL-method: ListByApp
+      x-stackQL-verb: select
+components:
+  schemas:
+    region:
+      description: A region represents a geographic location in which your application may run.
+      type:
+      - object
+      properties:
+        country:
+          $ref: '#/components/schemas/country'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        description:
+          $ref: '#/components/schemas/description'
+        id:
+          $ref: '#/components/schemas/id'
+        locale:
+          $ref: '#/components/schemas/locale'
+        name:
+          $ref: '#/components/schemas/name'
+        private_capable:
+          $ref: '#/components/schemas/private_capable'
+        provider:
+          $ref: '#/components/schemas/provider'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    stack:
+      description: Stacks are the different application execution environments available in the Heroku platform.
+      type:
+      - object
+      properties:
+        default:
+          $ref: '#/components/schemas/default'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        state:
+          $ref: '#/components/schemas/state'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    default:
+      description: indicates this stack is the default for new apps
+      readOnly: true
+      type:
+      - boolean
+    created_at:
+      description: when stack was introduced
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    id:
+      description: unique identifier of stack
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    name:
+      description: unique name of stack
+      readOnly: true
+      type:
+      - string
+    state:
+      description: 'availability of this stack: beta, deprecated or public'
+      readOnly: true
+      type:
+      - string
+    updated_at:
+      description: when stack was last modified
+      format: date-time
+      readOnly: true
+      type:
+      - string
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    region:
+      id: heroku.platform.region
+      name: region
+      title: Region
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1regions~1{region_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1regions/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/region/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/region/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    stack:
+      id: heroku.platform.stack
+      name: stack
+      title: Stack
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1stacks~1{stack_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1stacks/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        ListByApp:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1available-stacks/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/stack/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/stack/methods/List'
+        - $ref: '#/components/x-stackQL-resources/stack/methods/ListByApp'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/releases.yaml
+++ b/provider/heroku/v0/services/releases.yaml
@@ -1,0 +1,724 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Releases
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /apps/{app_identity}/oci-images/{oci_image_identity}:
+    get:
+      summary: Info
+      description: Info for the OCI images of an app, filtered by identifier.
+      operationId: oci_imageInfo
+      tags:
+      - releases
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: oci_image_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of oci-image.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/oci-image'
+                type:
+                - array
+      x-stackQL-resource: oci-image
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /apps/{app_identity}/oci-images:
+    post:
+      summary: Create
+      description: Create an new OCI image of an app
+      operationId: oci_imageCreate
+      tags:
+      - releases
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/oci-image'
+      x-stackQL-resource: oci-image
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                architecture:
+                  $ref: '#/components/schemas/architecture'
+                base_image_name:
+                  $ref: '#/components/schemas/base_image_name'
+                base_top_layer:
+                  $ref: '#/components/schemas/base_top_layer'
+                commit:
+                  $ref: '#/components/schemas/commit'
+                commit_description:
+                  $ref: '#/components/schemas/commit_description'
+                image_repo:
+                  $ref: '#/components/schemas/image_repo'
+                digest:
+                  $ref: '#/components/schemas/digest'
+                stack:
+                  anyOf:
+                  - $ref: '#/components/schemas/name'
+                    example: cnb
+                  - $ref: '#/components/schemas/id'
+                process_types:
+                  $ref: '#/components/schemas/process_types'
+                buildpacks:
+                  $ref: '#/components/schemas/buildpacks'
+              type:
+              - object
+  /apps/{app_identity}/releases/{release_identity}:
+    get:
+      summary: Info
+      description: Info for existing release.
+      operationId: releaseInfo
+      tags:
+      - releases
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: release_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of release.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/release'
+      x-stackQL-resource: release
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /apps/{app_identity}/releases:
+    get:
+      summary: List
+      description: List existing releases.
+      operationId: releaseList
+      tags:
+      - releases
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/release'
+                type:
+                - array
+      x-stackQL-resource: release
+      x-stackQL-method: List
+      x-stackQL-verb: select
+    post:
+      summary: Rollback
+      description: Rollback to an existing release.
+      operationId: releaseRollback
+      tags:
+      - releases
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/release'
+      x-stackQL-resource: release
+      x-stackQL-method: Rollback
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                release:
+                  $ref: '#/components/schemas/id'
+              required:
+              - release
+              type:
+              - object
+  /apps/{app_identity}/slugs/{slug_identity}:
+    get:
+      summary: Info
+      description: Info for existing slug.
+      operationId: slugInfo
+      tags:
+      - releases
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      - name: slug_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of slug.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/slug'
+      x-stackQL-resource: slug
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /apps/{app_identity}/slugs:
+    post:
+      summary: Create
+      description: Create a new slug. For more information please refer to [Deploying Slugs using the Platform API](https://devcenter.heroku.com/articles/platform-api-deploying-slugs).
+      operationId: slugCreate
+      tags:
+      - releases
+      parameters:
+      - name: app_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of app.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/slug'
+                example:
+                  blob:
+                    method: PUT
+                    url: https://api.heroku.com/slugs/1234.tgz
+                  buildpack_provided_description: Ruby/Rack
+                  checksum: SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+                  commit: 60883d9e8947a57e04dc9124f25df004866a2051
+                  commit_description: fixed a bug with API documentation
+                  created_at: '2012-01-01T12:00:00Z'
+                  id: 01234567-89ab-cdef-0123-456789abcdef
+                  process_types:
+                    web: ./bin/web -p $PORT
+                  size: 2048
+                  stack:
+                    id: 01234567-89ab-cdef-0123-456789abcdef
+                    name: heroku-18
+                  updated_at: '2012-01-01T12:00:00Z'
+      x-stackQL-resource: slug
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                buildpack_provided_description:
+                  $ref: '#/components/schemas/buildpack_provided_description'
+                checksum:
+                  $ref: '#/components/schemas/checksum'
+                commit:
+                  $ref: '#/components/schemas/commit'
+                commit_description:
+                  $ref: '#/components/schemas/commit_description'
+                process_types:
+                  $ref: '#/components/schemas/process_types'
+                stack:
+                  $ref: '#/components/schemas/identity'
+              required:
+              - process_types
+              type:
+              - object
+components:
+  schemas:
+    oci-image:
+      description: An OCI (Open Container Initiative) image is a standardized format for packaging and distributing containerized
+        applications, ready to run on the platform.
+      type:
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        base_image_name:
+          $ref: '#/components/schemas/base_image_name'
+        base_top_layer:
+          $ref: '#/components/schemas/base_top_layer'
+        commit:
+          $ref: '#/components/schemas/commit'
+        commit_description:
+          $ref: '#/components/schemas/commit_description'
+        image_repo:
+          $ref: '#/components/schemas/image_repo'
+        digest:
+          $ref: '#/components/schemas/digest'
+        stack:
+          $ref: '#/components/schemas/stack'
+        process_types:
+          $ref: '#/components/schemas/process_types'
+        buildpacks:
+          $ref: '#/components/schemas/buildpacks'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        architecture:
+          $ref: '#/components/schemas/architecture'
+    id:
+      description: unique identifier of the OCI image
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    base_image_name:
+      description: name of the image used for the base layers of the OCI image
+      readOnly: false
+      type:
+      - string
+    base_top_layer:
+      description: the digest of the top most layer of the base image.
+      readOnly: false
+      type:
+      - string
+    commit:
+      description: 'identification of the code in your version control system (eg: SHA of the git HEAD)'
+      readOnly: false
+      type:
+      - string
+    commit_description:
+      description: an optional description of the provided commit
+      readOnly: false
+      type:
+      - string
+    image_repo:
+      description: name of the image registry repository used for storage
+      readOnly: false
+      type:
+      - string
+    digest:
+      description: unique identifier representing the content of the OCI image
+      readOnly: false
+      type:
+      - string
+    stack:
+      description: stack associated to the OCI image
+      readOnly: false
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+      type:
+      - object
+    name:
+      description: unique name of stack
+      readOnly: true
+      type:
+      - string
+    process_types:
+      description: process types of the OCI image
+      patternProperties:
+        ^[-\w]{1,128}$:
+          $ref: '#/components/schemas/process_type'
+      type:
+      - object
+    process_type:
+      description: process type information such as names and commands
+      readOnly: false
+      properties:
+        name:
+          description: name of the process type
+          type:
+          - string
+        display_cmd:
+          description: the detailed command used for display purposes
+          type:
+          - string
+        command:
+          description: the command that will be executed
+          type:
+          - string
+        working_dir:
+          description: working directory
+          type:
+          - string
+        default:
+          description: true if it is the default process type
+          type:
+          - boolean
+          - 'null'
+      type:
+      - object
+    buildpacks:
+      description: buildpacks of the OCI image
+      items:
+        $ref: '#/components/schemas/buildpack'
+      type:
+      - array
+    buildpack:
+      description: set of executables that inspects app source code and creates a plan to build and run your image
+      readOnly: false
+      properties:
+        id:
+          description: identifier of the buildpack
+          type:
+          - string
+        version:
+          description: version of the buildpack
+          type:
+          - string
+        homepage:
+          description: homepage of the buildpack
+          type:
+          - string
+      type:
+      - object
+    created_at:
+      description: when the OCI image was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    updated_at:
+      description: when the OCI image was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    architecture:
+      description: build architecture for OCI image
+      readOnly: false
+      type:
+      - string
+      - 'null'
+    release:
+      description: A release represents a combination of code, config vars and add-ons for an app on Heroku.
+      type:
+      - object
+      properties:
+        addon_plan_names:
+          description: add-on plans installed on the app for this release
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/name'
+        artifacts:
+          description: build artifacts for the release
+          type:
+          - array
+          items:
+            $ref: '#/components/schemas/artifact'
+        app:
+          description: app involved in the release
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        description:
+          $ref: '#/components/schemas/description'
+        id:
+          $ref: '#/components/schemas/id'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        slug:
+          description: slug running in this release
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - object
+          - 'null'
+        status:
+          $ref: '#/components/schemas/status'
+        user:
+          description: user that created the release
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            email:
+              $ref: '#/components/schemas/email'
+          type:
+          - object
+        version:
+          $ref: '#/components/schemas/version'
+        current:
+          $ref: '#/components/schemas/current'
+        output_stream_url:
+          $ref: '#/components/schemas/output_stream_url'
+        eligible_for_rollback:
+          $ref: '#/components/schemas/eligible_for_rollback'
+    artifact:
+      description: a build artifact for the release
+      properties:
+        type:
+          description: type of artifact
+          type:
+          - string
+        id:
+          anyOf:
+          - $ref: '#/components/schemas/id'
+          - $ref: '#/components/schemas/id'
+      readOnly: true
+      type:
+      - object
+    description:
+      description: description of changes in this release
+      readOnly: true
+      type:
+      - string
+    status:
+      description: current status of the release
+      enum:
+      - failed
+      - pending
+      - succeeded
+      readOnly: true
+      type:
+      - string
+    email:
+      description: unique email address of account
+      format: email
+      readOnly: false
+      type:
+      - string
+    version:
+      description: unique version assigned to the release
+      readOnly: true
+      type:
+      - integer
+    current:
+      description: indicates this release as being the current one for the app
+      readOnly: true
+      type:
+      - boolean
+    output_stream_url:
+      description: Release command output will be available from this URL as a stream. The stream is available as either `text/plain`
+        or `text/event-stream`. Clients should be prepared to handle disconnects and can resume the stream by sending a `Range`
+        header (for `text/plain`) or a `Last-Event-Id` header (for `text/event-stream`).
+      readOnly: true
+      type:
+      - string
+      - 'null'
+    eligible_for_rollback:
+      description: indicates if this release is eligible for rollback
+      readOnly: true
+      type:
+      - boolean
+    slug:
+      description: A slug is a snapshot of your application code that is ready to run on the platform.
+      type:
+      - object
+      properties:
+        blob:
+          description: pointer to the url where clients can fetch or store the actual release binary
+          properties:
+            method:
+              $ref: '#/components/schemas/method'
+            url:
+              $ref: '#/components/schemas/url'
+          type:
+          - object
+        buildpack_provided_description:
+          $ref: '#/components/schemas/buildpack_provided_description'
+        checksum:
+          $ref: '#/components/schemas/checksum'
+        commit:
+          $ref: '#/components/schemas/commit'
+        commit_description:
+          $ref: '#/components/schemas/commit_description'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        process_types:
+          $ref: '#/components/schemas/process_types'
+        size:
+          $ref: '#/components/schemas/size'
+        stack:
+          description: identity of slug stack
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    method:
+      description: method to be used to interact with the slug blob
+      readOnly: true
+      type:
+      - string
+    url:
+      description: URL to interact with the slug blob
+      readOnly: true
+      type:
+      - string
+    buildpack_provided_description:
+      description: description from buildpack of slug
+      readOnly: false
+      type:
+      - 'null'
+      - string
+    checksum:
+      description: an optional checksum of the slug for verifying its integrity
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    size:
+      default: null
+      description: size of slug, in bytes
+      readOnly: true
+      type:
+      - integer
+      - 'null'
+    identity:
+      anyOf:
+      - $ref: '#/components/schemas/name'
+      - $ref: '#/components/schemas/id'
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    oci-image:
+      id: heroku.releases.oci-image
+      name: oci-image
+      title: Oci Image
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1oci-images~1{oci_image_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Create:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1oci-images/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/oci-image/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/oci-image/methods/Create'
+        update: []
+        delete: []
+        exec: []
+    release:
+      id: heroku.releases.release
+      name: release
+      title: Release
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1releases~1{release_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1releases/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Rollback:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1releases/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/release/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/release/methods/List'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/release/methods/Rollback'
+        update: []
+        delete: []
+        exec: []
+    slug:
+      id: heroku.releases.slug
+      name: slug
+      title: Slug
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1slugs~1{slug_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Create:
+          operation:
+            $ref: '#/paths/~1apps~1{app_identity}~1slugs/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/slug/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/slug/methods/Create'
+        update: []
+        delete: []
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/spaces.yaml
+++ b/provider/heroku/v0/services/spaces.yaml
@@ -1,0 +1,334 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Spaces
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /spaces:
+    get:
+      summary: List
+      description: List existing spaces.
+      operationId: spaceList
+      tags:
+      - spaces
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/space'
+                type:
+                - array
+      x-stackQL-resource: space
+      x-stackQL-method: List
+      x-stackQL-verb: select
+    post:
+      summary: Create
+      description: Create a new space.
+      operationId: spaceCreate
+      tags:
+      - spaces
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/space'
+      x-stackQL-resource: space
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+                team:
+                  $ref: '#/components/schemas/name'
+                region:
+                  $ref: '#/components/schemas/identity'
+                shield:
+                  $ref: '#/components/schemas/shield'
+                cidr:
+                  $ref: '#/components/schemas/cidr'
+                data_cidr:
+                  $ref: '#/components/schemas/data_cidr'
+                log_drain_url:
+                  $ref: '#/components/schemas/log_drain_url'
+                generation:
+                  description: unique name of the generation of the Heroku platform for this space
+                  example: cedar
+                  readOnly: true
+                  type:
+                  - string
+              required:
+              - name
+              - team
+              type:
+              - object
+  /spaces/{space_identity}:
+    get:
+      summary: Info
+      description: Info for existing space.
+      operationId: spaceInfo
+      tags:
+      - spaces
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/space'
+      x-stackQL-resource: space
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update an existing space.
+      operationId: spaceUpdate
+      tags:
+      - spaces
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/space'
+      x-stackQL-resource: space
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+              type:
+              - object
+    delete:
+      summary: Delete
+      description: Delete an existing space.
+      operationId: spaceDelete
+      tags:
+      - spaces
+      parameters:
+      - name: space_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of space.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: space
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+components:
+  schemas:
+    space:
+      description: A space is an isolated, highly available, secure app execution environment.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        organization:
+          description: organization that owns this space
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        team:
+          description: team that owns this space
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        region:
+          description: identity of space region
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        shield:
+          $ref: '#/components/schemas/shield'
+        state:
+          $ref: '#/components/schemas/state'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        cidr:
+          $ref: '#/components/schemas/cidr'
+        data_cidr:
+          $ref: '#/components/schemas/data_cidr'
+        generation:
+          $ref: '#/components/schemas/generation'
+    created_at:
+      description: when space was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    id:
+      description: unique identifier of space
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    name:
+      description: unique name of space
+      readOnly: false
+      pattern: ^[a-z0-9](?:[a-z0-9]|-(?!-))+[a-z0-9]$
+      type:
+      - string
+    shield:
+      description: true if this space has shield enabled
+      readOnly: true
+      type:
+      - boolean
+    state:
+      description: availability of this space
+      enum:
+      - allocating
+      - allocated
+      - deleting
+      readOnly: true
+      type:
+      - string
+    updated_at:
+      description: when space was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    cidr:
+      description: The RFC-1918 CIDR the Private Space will use. It must be a /16 in 10.0.0.0/8, 172.16.0.0/12 or 192.168.0.0/16
+      default: 10.0.0.0/16
+      pattern: ^((?:10|172\.(?:1[6-9]|2[0-9]|3[01])|192\.168)\..*.+\/16)$
+      readOnly: false
+      type:
+      - string
+    data_cidr:
+      description: The RFC-1918 CIDR that the Private Space will use for the Heroku-managed peering connection that's automatically
+        created when using Heroku Data add-ons. It must be between a /16 and a /20
+      readOnly: false
+      type:
+      - string
+    generation:
+      description: Generation of the Heroku platform for this space
+      readOnly: true
+      type:
+      - object
+      properties:
+        id:
+          description: unique identifier of the generation of the Heroku platform for this space
+          format: uuid
+          readOnly: true
+          type:
+          - string
+        name:
+          description: unique name of the generation of the Heroku platform for this space
+          readOnly: true
+          type:
+          - string
+    identity:
+      anyOf:
+      - $ref: '#/components/schemas/id'
+      - $ref: '#/components/schemas/name'
+    log_drain_url:
+      description: URL to which all apps will drain logs. Only settable during space creation and enables direct logging.
+        Must use HTTPS.
+      type:
+      - string
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    space:
+      id: heroku.spaces.space
+      name: space
+      title: Space
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1spaces/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Create:
+          operation:
+            $ref: '#/paths/~1spaces/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        Info:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1spaces~1{space_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/space/methods/List'
+        - $ref: '#/components/x-stackQL-resources/space/methods/Info'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/space/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/space/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/space/methods/Delete'
+        exec: []
+security:
+- herokuAuth: []

--- a/provider/heroku/v0/services/teams.yaml
+++ b/provider/heroku/v0/services/teams.yaml
@@ -1,0 +1,1297 @@
+openapi: 3.0.0
+info:
+  title: Heroku Platform API - Teams
+  description: The platform API empowers developers to automate, extend and combine Heroku with other services.
+  version: v0
+servers:
+- url: https://api.heroku.com
+paths:
+  /teams/{team_identity}/features/{team_feature_identity}:
+    get:
+      summary: Info
+      description: Info for an existing team feature.
+      operationId: team_featureInfo
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      - name: team_feature_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-feature.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-feature'
+      x-stackQL-resource: team-feature
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+  /teams/{team_identity}/features:
+    get:
+      summary: List
+      description: List existing team features.
+      operationId: team_featureList
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team-feature'
+                type:
+                - array
+      x-stackQL-resource: team-feature
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /teams/{team_name}/invitations:
+    get:
+      summary: List
+      description: Get a list of a team's Identity Providers
+      operationId: team_invitationList
+      tags:
+      - teams
+      parameters:
+      - name: team_name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for name of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team-invitation'
+                type:
+                - array
+      x-stackQL-resource: team-invitation
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /teams/{team_identity}/invitations:
+    put:
+      summary: Create
+      description: Create Team Invitation
+      operationId: team_invitationCreate
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-invitation'
+      x-stackQL-resource: team-invitation
+      x-stackQL-method: Create
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  $ref: '#/components/schemas/email'
+                role:
+                  $ref: '#/components/schemas/role'
+              required:
+              - email
+              - role
+              type:
+              - object
+  /teams/{team_identity}/invitations/{team_invitation_identity}:
+    delete:
+      summary: Revoke
+      description: Revoke a team invitation.
+      operationId: team_invitationRevoke
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      - name: team_invitation_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-invitation.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: team-invitation
+      x-stackQL-method: Revoke
+      x-stackQL-verb: select
+  /teams/invitations/{team_invitation_token}:
+    get:
+      summary: Get
+      description: Get an invitation by its token
+      operationId: team_invitationGet
+      tags:
+      - teams
+      parameters:
+      - name: team_invitation_token
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for token of team-invitation.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-invitation'
+      x-stackQL-resource: team-invitation
+      x-stackQL-method: Get
+      x-stackQL-verb: select
+  /teams/invitations/{team_invitation_token}/accept:
+    post:
+      summary: Accept
+      description: Accept Team Invitation
+      operationId: team_invitationAccept
+      tags:
+      - teams
+      parameters:
+      - name: team_invitation_token
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for token of team-invitation.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-member'
+      x-stackQL-resource: team-invitation
+      x-stackQL-method: Accept
+      x-stackQL-verb: insert
+  /teams/{team_identity}/members:
+    put:
+      summary: Create or Update
+      description: Create a new team member, or update their role.
+      operationId: team_memberCreateOrUpdate
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-member'
+      x-stackQL-resource: team-member
+      x-stackQL-method: CreateOrUpdate
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  $ref: '#/components/schemas/email'
+                federated:
+                  $ref: '#/components/schemas/federated'
+                role:
+                  $ref: '#/components/schemas/team_role'
+              required:
+              - email
+              - role
+              type:
+              - object
+    post:
+      summary: Create
+      description: Create a new team member.
+      operationId: team_memberCreate
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-member'
+      x-stackQL-resource: team-member
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  $ref: '#/components/schemas/email'
+                federated:
+                  $ref: '#/components/schemas/federated'
+                role:
+                  $ref: '#/components/schemas/team_role'
+              required:
+              - email
+              - role
+              type:
+              - object
+    patch:
+      summary: Update
+      description: Update a team member.
+      operationId: team_memberUpdate
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team-member'
+      x-stackQL-resource: team-member
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  $ref: '#/components/schemas/email'
+                federated:
+                  $ref: '#/components/schemas/federated'
+                role:
+                  $ref: '#/components/schemas/team_role'
+              required:
+              - email
+              - role
+              type:
+              - object
+    get:
+      summary: List
+      description: List members of the team.
+      operationId: team_memberList
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team-member'
+                type:
+                - array
+      x-stackQL-resource: team-member
+      x-stackQL-method: List
+      x-stackQL-verb: select
+  /teams/{team_identity}/members/{team_member_identity}:
+    delete:
+      summary: Delete
+      description: Remove a member from the team.
+      operationId: team_memberDelete
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      - name: team_member_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-member.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: team-member
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+  /teams/{team_identity}/members/{team_member_identity}/apps:
+    get:
+      summary: List By Member
+      description: List the apps of a team member.
+      operationId: team_memberListByMember
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      - name: team_member_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team-member.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team-app'
+                type:
+                - array
+      x-stackQL-resource: team-member
+      x-stackQL-method: ListByMember
+      x-stackQL-verb: select
+  /teams:
+    get:
+      summary: List
+      description: List teams in which you are a member.
+      operationId: teamList
+      tags:
+      - teams
+      parameters: []
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team'
+                type:
+                - array
+      x-stackQL-resource: team
+      x-stackQL-method: List
+      x-stackQL-verb: select
+    post:
+      summary: Create
+      description: Create a new team.
+      operationId: teamCreate
+      tags:
+      - teams
+      parameters: []
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team'
+      x-stackQL-resource: team
+      x-stackQL-method: Create
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+                address_1:
+                  $ref: '#/components/schemas/address_1'
+                address_2:
+                  $ref: '#/components/schemas/address_2'
+                card_number:
+                  $ref: '#/components/schemas/card_number'
+                city:
+                  $ref: '#/components/schemas/city'
+                country:
+                  $ref: '#/components/schemas/country'
+                cvv:
+                  $ref: '#/components/schemas/cvv'
+                expiration_month:
+                  $ref: '#/components/schemas/expiration_month'
+                expiration_year:
+                  $ref: '#/components/schemas/expiration_year'
+                first_name:
+                  $ref: '#/components/schemas/first_name'
+                last_name:
+                  $ref: '#/components/schemas/last_name'
+                other:
+                  $ref: '#/components/schemas/other'
+                postal_code:
+                  $ref: '#/components/schemas/postal_code'
+                state:
+                  $ref: '#/components/schemas/state'
+                nonce:
+                  $ref: '#/components/schemas/nonce'
+                device_data:
+                  $ref: '#/components/schemas/device_data'
+              required:
+              - name
+              type:
+              - object
+  /teams/{team_identity}:
+    get:
+      summary: Info
+      description: Info for a team.
+      operationId: teamInfo
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team'
+      x-stackQL-resource: team
+      x-stackQL-method: Info
+      x-stackQL-verb: select
+    patch:
+      summary: Update
+      description: Update team properties.
+      operationId: teamUpdate
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team'
+      x-stackQL-resource: team
+      x-stackQL-method: Update
+      x-stackQL-verb: update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                default:
+                  $ref: '#/components/schemas/default'
+                name:
+                  $ref: '#/components/schemas/name'
+              type:
+              - object
+    delete:
+      summary: Delete
+      description: Delete an existing team.
+      operationId: teamDelete
+      tags:
+      - teams
+      parameters:
+      - name: team_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of team.
+      responses:
+        '204':
+          description: No Content
+      x-stackQL-resource: team
+      x-stackQL-method: Delete
+      x-stackQL-verb: delete
+  /enterprise-accounts/{enterprise_account_identity}/teams:
+    get:
+      summary: List by Enterprise Account
+      description: List teams for an enterprise account.
+      operationId: teamListByEnterpriseAccount
+      tags:
+      - teams
+      parameters:
+      - name: enterprise_account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of enterprise-account.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/team'
+                type:
+                - array
+      x-stackQL-resource: team
+      x-stackQL-method: ListByEnterpriseAccount
+      x-stackQL-verb: select
+    post:
+      summary: Create in Enterprise Account
+      description: Create a team in an enterprise account.
+      operationId: teamCreateInEnterpriseAccount
+      tags:
+      - teams
+      parameters:
+      - name: enterprise_account_identity
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier for identity of enterprise-account.
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/team'
+      x-stackQL-resource: team
+      x-stackQL-method: CreateInEnterpriseAccount
+      x-stackQL-verb: insert
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  $ref: '#/components/schemas/name'
+              required:
+              - name
+              type:
+              - object
+components:
+  schemas:
+    team-feature:
+      description: A team feature represents a feature enabled on a team account.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        description:
+          $ref: '#/components/schemas/description'
+        doc_url:
+          $ref: '#/components/schemas/doc_url'
+        enabled:
+          $ref: '#/components/schemas/enabled'
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        state:
+          $ref: '#/components/schemas/state'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        display_name:
+          $ref: '#/components/schemas/display_name'
+        feedback_email:
+          $ref: '#/components/schemas/feedback_email'
+    created_at:
+      description: when team feature was created
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    description:
+      description: description of team feature
+      readOnly: true
+      type:
+      - string
+    doc_url:
+      description: documentation URL of team feature
+      readOnly: true
+      type:
+      - string
+    enabled:
+      description: whether or not team feature has been enabled
+      readOnly: false
+      type:
+      - boolean
+    id:
+      description: unique identifier of team feature
+      format: uuid
+      readOnly: true
+      type:
+      - string
+    name:
+      description: unique name of team feature
+      readOnly: true
+      type:
+      - string
+    state:
+      description: state of team feature
+      readOnly: true
+      type:
+      - string
+    updated_at:
+      description: when team feature was updated
+      format: date-time
+      readOnly: true
+      type:
+      - string
+    display_name:
+      description: user readable feature name
+      readOnly: true
+      type:
+      - string
+    feedback_email:
+      description: e-mail to send feedback about the feature
+      readOnly: true
+      type:
+      - string
+    team-invitation:
+      description: A team invitation represents an invite to a team.
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        id:
+          $ref: '#/components/schemas/id'
+        invited_by:
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        team:
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        role:
+          $ref: '#/components/schemas/role'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        user:
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+    email:
+      description: unique email address of account
+      format: email
+      readOnly: false
+      type:
+      - string
+    role:
+      description: role in the team
+      enum:
+      - admin
+      - collaborator
+      - member
+      - owner
+      - null
+      readOnly: true
+      type:
+      - 'null'
+      - string
+    team-member:
+      description: A team member is an individual with access to a team.
+      additionalProperties: false
+      required:
+      - created_at
+      - email
+      - federated
+      - updated_at
+      type:
+      - object
+      properties:
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        email:
+          $ref: '#/components/schemas/email'
+        federated:
+          $ref: '#/components/schemas/federated'
+        id:
+          $ref: '#/components/schemas/id'
+        identity_provider:
+          description: Identity Provider information the member is federated with
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              description: name of the identity provider
+              readOnly: true
+              type:
+              - string
+            redacted:
+              description: whether the identity_provider information is redacted or not
+              readOnly: true
+              type:
+              - boolean
+            owner:
+              $ref: '#/components/schemas/owner'
+          type:
+          - 'null'
+          - object
+        role:
+          $ref: '#/components/schemas/role'
+        two_factor_authentication:
+          $ref: '#/components/schemas/two_factor_authentication'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        user:
+          description: user information for the membership
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+    federated:
+      description: whether the user is federated and belongs to an Identity Provider
+      readOnly: true
+      type:
+      - boolean
+    owner:
+      description: entity that owns this identity provider
+      properties:
+        id:
+          description: unique identifier of the owner
+          format: uuid
+          readOnly: true
+          type:
+          - string
+        name:
+          description: name of the owner
+          readOnly: true
+          type:
+          - string
+        type:
+          description: type of the owner
+          enum:
+          - team
+          - enterprise-account
+          readOnly: true
+          type:
+          - string
+      readOnly: false
+      required:
+      - id
+      - type
+      type:
+      - object
+    two_factor_authentication:
+      description: whether the team member has two factor authentication enabled
+      readOnly: true
+      type:
+      - boolean
+    team_role:
+      description: role in the team
+      enum:
+      - admin
+      - viewer
+      - member
+      type:
+      - string
+    team-app:
+      description: A team app encapsulates the team specific functionality of Heroku apps.
+      type:
+      - object
+      properties:
+        archived_at:
+          $ref: '#/components/schemas/archived_at'
+        buildpack_provided_description:
+          $ref: '#/components/schemas/buildpack_provided_description'
+        build_stack:
+          description: identity of the stack that will be used for new builds
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        git_url:
+          $ref: '#/components/schemas/git_url'
+        id:
+          $ref: '#/components/schemas/id'
+        internal_routing:
+          $ref: '#/components/schemas/internal_routing'
+        joined:
+          $ref: '#/components/schemas/joined'
+        locked:
+          $ref: '#/components/schemas/locked'
+        maintenance:
+          $ref: '#/components/schemas/maintenance'
+        name:
+          $ref: '#/components/schemas/name'
+        team:
+          description: team that owns this app
+          properties:
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - 'null'
+          - object
+        owner:
+          description: identity of app owner
+          properties:
+            email:
+              $ref: '#/components/schemas/email'
+            id:
+              $ref: '#/components/schemas/id'
+          type:
+          - 'null'
+          - object
+        region:
+          description: identity of app region
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        released_at:
+          $ref: '#/components/schemas/released_at'
+        repo_size:
+          $ref: '#/components/schemas/repo_size'
+        slug_size:
+          $ref: '#/components/schemas/slug_size'
+        space:
+          description: identity of space
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - 'null'
+          - object
+        stack:
+          description: identity of app stack
+          properties:
+            id:
+              $ref: '#/components/schemas/id'
+            name:
+              $ref: '#/components/schemas/name'
+          type:
+          - object
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+        web_url:
+          $ref: '#/components/schemas/web_url'
+    team:
+      description: Teams allow you to manage access to a shared group of applications and other resources.
+      type:
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        created_at:
+          $ref: '#/components/schemas/created_at'
+        credit_card_collections:
+          $ref: '#/components/schemas/credit_card_collections'
+        default:
+          $ref: '#/components/schemas/default'
+        enterprise_account:
+          $ref: '#/components/schemas/enterprise_account'
+        identity_provider:
+          $ref: '#/components/schemas/identity_provider'
+        membership_limit:
+          $ref: '#/components/schemas/membership_limit'
+        name:
+          $ref: '#/components/schemas/name'
+        provisioned_licenses:
+          $ref: '#/components/schemas/provisioned_licenses'
+        role:
+          $ref: '#/components/schemas/role'
+        type:
+          $ref: '#/components/schemas/type'
+        updated_at:
+          $ref: '#/components/schemas/updated_at'
+    credit_card_collections:
+      description: whether charges incurred by the team are paid by credit card.
+      readOnly: true
+      type:
+      - boolean
+    default:
+      description: whether to use this team when none is specified
+      readOnly: false
+      type:
+      - boolean
+    enterprise_account:
+      type:
+      - 'null'
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+    identity_provider:
+      description: Identity Provider associated with the Team
+      type:
+      - 'null'
+      - object
+      properties:
+        id:
+          $ref: '#/components/schemas/id'
+        name:
+          $ref: '#/components/schemas/name'
+        owner:
+          $ref: '#/components/schemas/owner'
+    membership_limit:
+      description: upper limit of members allowed in a team.
+      readOnly: true
+      type:
+      - number
+      - 'null'
+    provisioned_licenses:
+      description: whether the team is provisioned licenses by salesforce.
+      readOnly: true
+      type:
+      - boolean
+    type:
+      description: type of team.
+      enum:
+      - enterprise
+      - team
+      readOnly: true
+      type:
+      - string
+    address_1:
+      type:
+      - string
+      description: street address line 1
+    address_2:
+      type:
+      - string
+      - 'null'
+      description: street address line 2
+    card_number:
+      type:
+      - string
+      - 'null'
+      description: encrypted card number of payment method
+    city:
+      type:
+      - string
+      description: city
+    country:
+      type:
+      - string
+      description: country
+    cvv:
+      type:
+      - string
+      - 'null'
+      description: card verification value
+    expiration_month:
+      type:
+      - string
+      - 'null'
+      description: expiration month
+    expiration_year:
+      type:
+      - string
+      - 'null'
+      description: expiration year
+    first_name:
+      type:
+      - string
+      description: the first name for payment method
+    last_name:
+      type:
+      - string
+      description: the last name for payment method
+    other:
+      type:
+      - string
+      - 'null'
+      description: metadata
+    postal_code:
+      type:
+      - string
+      description: postal code
+    nonce:
+      type:
+      - string
+      - 'null'
+      description: Nonce generated by Braintree hosted fields form
+    device_data:
+      type:
+      - string
+      - 'null'
+      description: Device data string generated by the client
+  securitySchemes:
+    herokuAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+  x-stackQL-resources:
+    team-feature:
+      id: heroku.teams.team-feature
+      name: team-feature
+      title: Team Feature
+      methods:
+        Info:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1features~1{team_feature_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1features/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-feature/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/team-feature/methods/List'
+        insert: []
+        update: []
+        delete: []
+        exec: []
+    team-invitation:
+      id: heroku.teams.team-invitation
+      name: team-invitation
+      title: Team Invitation
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1teams~1{team_name}~1invitations/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Create:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1invitations/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Revoke:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1invitations~1{team_invitation_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        Get:
+          operation:
+            $ref: '#/paths/~1teams~1invitations~1{team_invitation_token}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Accept:
+          operation:
+            $ref: '#/paths/~1teams~1invitations~1{team_invitation_token}~1accept/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-invitation/methods/List'
+        - $ref: '#/components/x-stackQL-resources/team-invitation/methods/Revoke'
+        - $ref: '#/components/x-stackQL-resources/team-invitation/methods/Get'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/team-invitation/methods/Accept'
+        update:
+        - $ref: '#/components/x-stackQL-resources/team-invitation/methods/Create'
+        delete: []
+        exec: []
+    team-member:
+      id: heroku.teams.team-member
+      name: team-member
+      title: Team Member
+      methods:
+        CreateOrUpdate:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1members/put'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Create:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1members/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        Update:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1members/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        List:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1members/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1members~1{team_member_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        ListByMember:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}~1members~1{team_member_identity}~1apps/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team-member/methods/List'
+        - $ref: '#/components/x-stackQL-resources/team-member/methods/ListByMember'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/team-member/methods/CreateOrUpdate'
+        - $ref: '#/components/x-stackQL-resources/team-member/methods/Create'
+        update:
+        - $ref: '#/components/x-stackQL-resources/team-member/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/team-member/methods/Delete'
+        exec: []
+    team:
+      id: heroku.teams.team
+      name: team
+      title: Team
+      methods:
+        List:
+          operation:
+            $ref: '#/paths/~1teams/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Create:
+          operation:
+            $ref: '#/paths/~1teams/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+        Info:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Update:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}/patch'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        Delete:
+          operation:
+            $ref: '#/paths/~1teams~1{team_identity}/delete'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '204'
+        ListByEnterpriseAccount:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_identity}~1teams/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+        CreateInEnterpriseAccount:
+          operation:
+            $ref: '#/paths/~1enterprise-accounts~1{enterprise_account_identity}~1teams/post'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '201'
+      sqlVerbs:
+        select:
+        - $ref: '#/components/x-stackQL-resources/team/methods/List'
+        - $ref: '#/components/x-stackQL-resources/team/methods/Info'
+        - $ref: '#/components/x-stackQL-resources/team/methods/ListByEnterpriseAccount'
+        insert:
+        - $ref: '#/components/x-stackQL-resources/team/methods/Create'
+        - $ref: '#/components/x-stackQL-resources/team/methods/CreateInEnterpriseAccount'
+        update:
+        - $ref: '#/components/x-stackQL-resources/team/methods/Update'
+        delete:
+        - $ref: '#/components/x-stackQL-resources/team/methods/Delete'
+        exec: []
+security:
+- herokuAuth: []

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,19076 @@
+{
+  "$schema": "http://interagent.github.io/interagent-hyper-schema",
+  "type": [
+    "object"
+  ],
+  "definitions": {
+    "account-delinquency": {
+      "description": "A Heroku account becomes delinquent due to non-payment. We [suspend and delete](https://help.heroku.com/EREVRILX/what-happens-if-i-have-unpaid-heroku-invoices) delinquent accounts if their invoices remain unpaid.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Account Delinquency",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "scheduled_suspension_time": {
+          "description": "scheduled time of when we will suspend your account due to delinquency",
+          "example": "2024-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scheduled_deletion_time": {
+          "description": "scheduled time of when we will delete your account due to delinquency",
+          "example": "2024-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Account delinquency information.",
+          "href": "/account/delinquency",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/account-delinquency"
+          },
+          "title": "Info"
+        }
+      ],
+      "properties": {
+        "scheduled_suspension_time": {
+          "$ref": "#/definitions/account-delinquency/definitions/scheduled_suspension_time"
+        },
+        "scheduled_deletion_time": {
+          "$ref": "#/definitions/account-delinquency/definitions/scheduled_deletion_time"
+        }
+      }
+    },
+    "account-feature": {
+      "description": "An account feature represents a Heroku labs capability that can be enabled or disabled for an account on Heroku.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Account Feature",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when account feature was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of account feature",
+          "example": "Causes account to example.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "doc_url": {
+          "description": "documentation URL of account feature",
+          "example": "http://devcenter.heroku.com/articles/example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "enabled": {
+          "description": "whether or not account feature has been enabled",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of account feature",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/account-feature/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/account-feature/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of account feature",
+          "example": "name",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state of account feature",
+          "example": "public",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when account feature was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "display_name": {
+          "description": "user readable feature name",
+          "example": "My Feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "feedback_email": {
+          "description": "e-mail to send feedback about the feature",
+          "example": "feedback@heroku.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for an existing account feature.",
+          "href": "/account/features/{(%23%2Fdefinitions%2Faccount-feature%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/account-feature"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing account features.",
+          "href": "/account/features",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/account-feature"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update an existing account feature.",
+          "href": "/account/features/{(%23%2Fdefinitions%2Faccount-feature%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "enabled": {
+                "$ref": "#/definitions/account-feature/definitions/enabled"
+              }
+            },
+            "required": [
+              "enabled"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/account-feature"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/account-feature/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/account-feature/definitions/description"
+        },
+        "doc_url": {
+          "$ref": "#/definitions/account-feature/definitions/doc_url"
+        },
+        "enabled": {
+          "$ref": "#/definitions/account-feature/definitions/enabled"
+        },
+        "id": {
+          "$ref": "#/definitions/account-feature/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/account-feature/definitions/name"
+        },
+        "state": {
+          "$ref": "#/definitions/account-feature/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/account-feature/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/account-feature/definitions/display_name"
+        },
+        "feedback_email": {
+          "$ref": "#/definitions/account-feature/definitions/feedback_email"
+        }
+      }
+    },
+    "account": {
+      "description": "An account represents an individual signed up to use the Heroku platform.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Account",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "allow_tracking": {
+          "default": true,
+          "description": "whether to allow third party web activity tracking",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "beta": {
+          "default": false,
+          "description": "whether allowed to utilize beta Heroku features",
+          "example": false,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "created_at": {
+          "description": "when account was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "country_of_residence": {
+          "description": "country where account owner resides",
+          "example": "United States",
+          "readOnly": false,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "email": {
+          "description": "unique email address of account",
+          "example": "username@example.com",
+          "format": "email",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "federated": {
+          "description": "whether the user is federated and belongs to an Identity Provider",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of an account",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/account/definitions/self"
+            }
+          ]
+        },
+        "last_login": {
+          "description": "when account last authorized with Heroku",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "full name of the account owner",
+          "example": "Tina Edmonds",
+          "readOnly": false,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "password": {
+          "description": "current password on the account",
+          "example": "currentpassword",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "self": {
+          "description": "Implicit reference to currently authorized user",
+          "enum": [
+            "~"
+          ],
+          "example": "~",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "sms_number": {
+          "description": "SMS number of account",
+          "example": "+1 ***-***-1234",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suspended_at": {
+          "description": "when account was suspended",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "delinquent_at": {
+          "description": "when account became delinquent",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "two_factor_authentication": {
+          "description": "whether two-factor auth is enabled on the account",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "updated_at": {
+          "description": "when account was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "verified": {
+          "default": false,
+          "description": "whether account has been verified with billing information",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for account.",
+          "href": "/account",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/account"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update account.",
+          "href": "/account",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "allow_tracking": {
+                "$ref": "#/definitions/account/definitions/allow_tracking"
+              },
+              "beta": {
+                "$ref": "#/definitions/account/definitions/beta"
+              },
+              "name": {
+                "$ref": "#/definitions/account/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/account"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Delete account. Note that this action cannot be undone. Note: This endpoint requires the HTTP_HEROKU_PASSWORD or HTTP_HEROKU_PASSWORD_BASE64 header be set correctly for the user account.",
+          "href": "/account",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/account"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for account.",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/account"
+          },
+          "title": "Info By User"
+        },
+        {
+          "description": "Update account.",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "allow_tracking": {
+                "$ref": "#/definitions/account/definitions/allow_tracking"
+              },
+              "beta": {
+                "$ref": "#/definitions/account/definitions/beta"
+              },
+              "name": {
+                "$ref": "#/definitions/account/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/account"
+          },
+          "title": "Update By User"
+        },
+        {
+          "description": "Delete account. Note that this action cannot be undone. Note: This endpoint requires the HTTP_HEROKU_PASSWORD or HTTP_HEROKU_PASSWORD_BASE64 header be set correctly for the user account.",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/account"
+          },
+          "title": "Delete By User"
+        }
+      ],
+      "properties": {
+        "allow_tracking": {
+          "$ref": "#/definitions/account/definitions/allow_tracking"
+        },
+        "beta": {
+          "$ref": "#/definitions/account/definitions/beta"
+        },
+        "created_at": {
+          "$ref": "#/definitions/account/definitions/created_at"
+        },
+        "email": {
+          "$ref": "#/definitions/account/definitions/email"
+        },
+        "federated": {
+          "$ref": "#/definitions/account/definitions/federated"
+        },
+        "id": {
+          "$ref": "#/definitions/account/definitions/id"
+        },
+        "identity_provider": {
+          "description": "Identity Provider details for federated users.",
+          "strictProperties": true,
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/identity-provider/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/identity-provider/definitions/name"
+            },
+            "team": {
+              "type": [
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "$ref": "#/definitions/team/definitions/name"
+                }
+              }
+            },
+            "organization": {
+              "type": [
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "$ref": "#/definitions/team/definitions/name"
+                }
+              }
+            },
+            "owner": {
+              "$ref": "#/definitions/identity-provider/definitions/owner"
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "last_login": {
+          "$ref": "#/definitions/account/definitions/last_login"
+        },
+        "name": {
+          "$ref": "#/definitions/account/definitions/name"
+        },
+        "sms_number": {
+          "$ref": "#/definitions/account/definitions/sms_number"
+        },
+        "suspended_at": {
+          "$ref": "#/definitions/account/definitions/suspended_at"
+        },
+        "delinquent_at": {
+          "$ref": "#/definitions/account/definitions/delinquent_at"
+        },
+        "two_factor_authentication": {
+          "$ref": "#/definitions/account/definitions/two_factor_authentication"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/account/definitions/updated_at"
+        },
+        "verified": {
+          "$ref": "#/definitions/account/definitions/verified"
+        },
+        "country_of_residence": {
+          "$ref": "#/definitions/account/definitions/country_of_residence"
+        },
+        "default_organization": {
+          "description": "team selected by default",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "default_team": {
+          "description": "team selected by default",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      }
+    },
+    "add-on-action": {
+      "description": "Add-on Actions are lifecycle operations for add-on provisioning and deprovisioning. They allow add-on providers to (de)provision add-ons in the background and then report back when (de)provisioning is complete.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Action",
+      "type": [
+        "object"
+      ],
+      "definitions": {},
+      "links": [
+        {
+          "description": "Mark an add-on as provisioned for use.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/actions/provision",
+          "method": "POST",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Provision"
+        },
+        {
+          "description": "Mark an add-on as deprovisioned.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/actions/deprovision",
+          "method": "POST",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Deprovision"
+        }
+      ],
+      "properties": {}
+    },
+    "add-on-attachment": {
+      "description": "An add-on attachment represents a connection between an app and an add-on that it has been given access to.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Attachment",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "confirm": {
+          "description": "name of owning app for confirmation",
+          "example": "example",
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when add-on attachment was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this add-on attachment",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/add-on-attachment/definitions/id"
+            }
+          ]
+        },
+        "scopedIdentity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/add-on-attachment/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/add-on-attachment/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name for this add-on attachment to this app",
+          "example": "DATABASE",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "namespace": {
+          "description": "attachment namespace",
+          "example": "role:analytics",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when add-on attachment was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "web_url": {
+          "description": "URL for logging into web interface of add-on in attached app context",
+          "example": "https://postgres.heroku.com/databases/01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uri",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "log_input_url": {
+          "description": "URL for add-on partners to write to an add-on's logs",
+          "example": "https://token:t.abcdef12-3456-7890-abcd-ef1234567890@1.us.logplex.io/logs",
+          "type": [
+            "null",
+            "string"
+          ],
+          "readOnly": true
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new add-on attachment.",
+          "href": "/addon-attachments",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "addon": {
+                "$ref": "#/definitions/add-on/definitions/identity"
+              },
+              "app": {
+                "$ref": "#/definitions/app/definitions/identity"
+              },
+              "confirm": {
+                "$ref": "#/definitions/add-on-attachment/definitions/confirm"
+              },
+              "name": {
+                "$ref": "#/definitions/add-on-attachment/definitions/name"
+              },
+              "namespace": {
+                "$ref": "#/definitions/add-on-attachment/definitions/namespace"
+              }
+            },
+            "required": [
+              "addon",
+              "app"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-attachment"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing add-on attachment.",
+          "href": "/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-attachment"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for existing add-on attachment.",
+          "href": "/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-attachment"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing add-on attachments.",
+          "href": "/addon-attachments",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-attachment"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List existing add-on attachments for an add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/addon-attachments",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-attachment"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by Add-on"
+        },
+        {
+          "description": "List existing add-on attachments for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addon-attachments",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-attachment"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by App"
+        },
+        {
+          "description": "Info for existing add-on attachment for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2FscopedIdentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-attachment"
+          },
+          "title": "Info by App"
+        },
+        {
+          "description": "Resolve an add-on attachment from a name, optionally passing an app name. If there are matches it returns at least one add-on attachment (exact match) or many.",
+          "href": "/actions/addon-attachments/resolve",
+          "method": "POST",
+          "rel": "resolve",
+          "schema": {
+            "properties": {
+              "addon_attachment": {
+                "$ref": "#/definitions/add-on-attachment/definitions/name"
+              },
+              "app": {
+                "$ref": "#/definitions/app/definitions/name"
+              },
+              "addon_service": {
+                "$ref": "#/definitions/add-on-service/definitions/name"
+              }
+            },
+            "required": [
+              "addon_attachment"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-attachment"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Resolution"
+        }
+      ],
+      "properties": {
+        "addon": {
+          "description": "identity of add-on",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/add-on/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/add-on/definitions/name"
+            },
+            "app": {
+              "description": "billing application associated with this add-on",
+              "type": [
+                "object"
+              ],
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/app/definitions/id"
+                },
+                "name": {
+                  "$ref": "#/definitions/app/definitions/name"
+                }
+              },
+              "strictProperties": true
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "name",
+            "app"
+          ],
+          "type": [
+            "object"
+          ]
+        },
+        "app": {
+          "description": "application that is attached to add-on",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/add-on-attachment/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/add-on-attachment/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/add-on-attachment/definitions/name"
+        },
+        "namespace": {
+          "$ref": "#/definitions/add-on-attachment/definitions/namespace"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/add-on-attachment/definitions/updated_at"
+        },
+        "web_url": {
+          "$ref": "#/definitions/add-on-attachment/definitions/web_url"
+        },
+        "log_input_url": {
+          "$ref": "#/definitions/add-on-attachment/definitions/log_input_url"
+        }
+      }
+    },
+    "add-on-config": {
+      "description": "Configuration of an Add-on",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Config",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/add-on-config/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of the config",
+          "example": "FOO",
+          "type": [
+            "string"
+          ]
+        },
+        "value": {
+          "description": "value of the config",
+          "example": "bar",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get an add-on's config. Accessible by customers with access and by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/config",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-config"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update an add-on's config. Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/config",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "config": {
+                "items": {
+                  "$ref": "#/definitions/add-on-config"
+                },
+                "type": [
+                  "array"
+                ]
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "type": [
+              "array"
+            ],
+            "items": {
+              "$ref": "#/definitions/add-on-config"
+            }
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/add-on-config/definitions/name"
+        },
+        "value": {
+          "$ref": "#/definitions/add-on-config/definitions/value"
+        }
+      }
+    },
+    "add-on-plan-action": {
+      "description": "Add-on Plan Actions are Provider functionality for specific add-on installations",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Plan Action",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "a unique identifier",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/id"
+        },
+        "label": {
+          "description": "the display text shown in Dashboard",
+          "example": "Example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "action": {
+          "description": "identifier of the action to take that is sent via SSO",
+          "example": "example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "url": {
+          "description": "absolute URL to use instead of an action",
+          "example": "http://example.com?resource_id=:resource_id",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "requires_owner": {
+          "description": "if the action requires the user to own the app",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/id"
+        },
+        "label": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/label"
+        },
+        "action": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/action"
+        },
+        "url": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/url"
+        },
+        "requires_owner": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/requires_owner"
+        }
+      }
+    },
+    "add-on-region-capability": {
+      "description": "Add-on region capabilities represent the relationship between an Add-on Service and a specific Region. Only Beta and GA add-ons are returned by these endpoints.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Region Capability",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of this add-on-region-capability",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "supports_private_networking": {
+          "description": "whether the add-on can be installed to a Space",
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/add-on-region-capability/definitions/id"
+        }
+      },
+      "links": [
+        {
+          "description": "List all existing add-on region capabilities.",
+          "href": "/addon-region-capabilities",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-region-capability"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List existing add-on region capabilities for an add-on-service",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/region-capabilities",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-region-capability"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by Add-on Service"
+        },
+        {
+          "description": "List existing add-on region capabilities for a region.",
+          "href": "/regions/{(%23%2Fdefinitions%2Fregion%2Fdefinitions%2Fidentity)}/addon-region-capabilities",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-region-capability"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Region"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/add-on-region-capability/definitions/id"
+        },
+        "supports_private_networking": {
+          "$ref": "#/definitions/add-on-region-capability/definitions/supports_private_networking"
+        },
+        "addon_service": {
+          "$ref": "#/definitions/add-on-service"
+        },
+        "region": {
+          "$ref": "#/definitions/region"
+        }
+      }
+    },
+    "add-on-service": {
+      "description": "Add-on services represent add-ons that may be provisioned for apps. Endpoints under add-on services can be accessed without authentication.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Service",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "cli_plugin_name": {
+          "description": "npm package name of the add-on service's Heroku CLI plugin",
+          "example": "heroku-papertrail",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "created_at": {
+          "description": "when add-on-service was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "human_name": {
+          "description": "human-readable name of the add-on service provider",
+          "example": "Heroku Postgres",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this add-on-service",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/add-on-service/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/add-on-service/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of this add-on-service",
+          "example": "heroku-postgresql",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "release status for add-on service",
+          "enum": [
+            "alpha",
+            "beta",
+            "ga",
+            "shutdown"
+          ],
+          "example": "ga",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "supports_multiple_installations": {
+          "default": false,
+          "description": "whether or not apps can have access to more than one instance of this add-on at the same time",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "supports_sharing": {
+          "default": false,
+          "description": "whether or not apps can have access to add-ons billed to a different app",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "updated_at": {
+          "description": "when add-on-service was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "supported_generations": {
+          "description": "generations supported by this add-on",
+          "readonly": true,
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/generation/definitions/name",
+                "example": "cedar"
+              },
+              "id": {
+                "$ref": "#/definitions/generation/definitions/id"
+              }
+            }
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing add-on-service.",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-service"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing add-on-services.",
+          "href": "/addon-services",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-service"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "cli_plugin_name": {
+          "$ref": "#/definitions/add-on-service/definitions/cli_plugin_name"
+        },
+        "created_at": {
+          "$ref": "#/definitions/add-on-service/definitions/created_at"
+        },
+        "human_name": {
+          "$ref": "#/definitions/add-on-service/definitions/human_name"
+        },
+        "id": {
+          "$ref": "#/definitions/add-on-service/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/add-on-service/definitions/name"
+        },
+        "state": {
+          "$ref": "#/definitions/add-on-service/definitions/state"
+        },
+        "supports_multiple_installations": {
+          "$ref": "#/definitions/add-on-service/definitions/supports_multiple_installations"
+        },
+        "supports_sharing": {
+          "$ref": "#/definitions/add-on-service/definitions/supports_sharing"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/add-on-service/definitions/updated_at"
+        },
+        "supported_generations": {
+          "$ref": "#/definitions/add-on-service/definitions/supported_generations"
+        }
+      }
+    },
+    "add-on-webhook-delivery": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - Add-on Webhook Delivery",
+      "description": "Represents the delivery of a webhook notification, including its current status.",
+      "stability": "production",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "links": [
+        {
+          "description": "Returns the info for an existing delivery.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhook-deliveries/{(%23%2Fdefinitions%2Fapp-webhook-delivery%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook-delivery"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Lists existing deliveries for an add-on.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhook-deliveries",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-webhook-delivery"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ]
+    },
+    "add-on-webhook-event": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - Add-on Webhook Event",
+      "description": "Represents a webhook event that occurred.",
+      "stability": "production",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "links": [
+        {
+          "description": "Returns the info for a specified webhook event.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhook-events/{(%23%2Fdefinitions%2Fapp-webhook-event%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook-event"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Lists existing webhook events for an add-on.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhook-events",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-webhook-event"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ]
+    },
+    "add-on-webhook": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - Add-on Webhook",
+      "description": "Represents the details of a webhook subscription",
+      "stability": "production",
+      "strictProperties": false,
+      "additionalProperties": false,
+      "required": [
+        "created_at",
+        "id",
+        "include",
+        "level",
+        "updated_at",
+        "url"
+      ],
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "addon_webhook": {
+          "properties": {
+            "addon": {
+              "description": "identity of add-on. Only used for add-on partner webhooks.",
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/add-on/definitions/id"
+                },
+                "name": {
+                  "$ref": "#/definitions/add-on/definitions/name"
+                }
+              },
+              "strictProperties": true,
+              "type": [
+                "object"
+              ]
+            },
+            "created_at": {
+              "$ref": "#/definitions/app-webhook/definitions/created_at"
+            },
+            "id": {
+              "$ref": "#/definitions/app-webhook/definitions/id"
+            },
+            "include": {
+              "$ref": "#/definitions/app-webhook/definitions/include"
+            },
+            "level": {
+              "$ref": "#/definitions/app-webhook/definitions/level"
+            },
+            "updated_at": {
+              "$ref": "#/definitions/app-webhook/definitions/updated_at"
+            },
+            "url": {
+              "$ref": "#/definitions/app-webhook/definitions/url"
+            }
+          },
+          "description": "add-on webhook",
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create an add-on webhook subscription.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhooks",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "authorization": {
+                "$ref": "#/definitions/app-webhook/definitions/authorization"
+              },
+              "include": {
+                "$ref": "#/definitions/app-webhook/definitions/include"
+              },
+              "level": {
+                "$ref": "#/definitions/app-webhook/definitions/level"
+              },
+              "secret": {
+                "$ref": "#/definitions/app-webhook/definitions/secret"
+              },
+              "url": {
+                "$ref": "#/definitions/app-webhook/definitions/url"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "include",
+              "level",
+              "url"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-webhook/definitions/addon_webhook"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Removes an add-on webhook subscription.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-webhook/definitions/addon_webhook"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Returns the info for an add-on webhook subscription.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-webhook/definitions/addon_webhook"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List all webhook subscriptions for a particular add-on.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhooks",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-webhook/definitions/addon_webhook"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Updates the details of an add-on webhook subscription.  Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "authorization": {
+                "$ref": "#/definitions/app-webhook/definitions/authorization"
+              },
+              "include": {
+                "$ref": "#/definitions/app-webhook/definitions/include"
+              },
+              "level": {
+                "$ref": "#/definitions/app-webhook/definitions/level"
+              },
+              "secret": {
+                "$ref": "#/definitions/app-webhook/definitions/secret"
+              },
+              "url": {
+                "$ref": "#/definitions/app-webhook/definitions/url"
+              }
+            },
+            "strictProperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-webhook/definitions/addon_webhook"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/app-webhook/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/app-webhook/definitions/id"
+        },
+        "include": {
+          "$ref": "#/definitions/app-webhook/definitions/include"
+        },
+        "level": {
+          "$ref": "#/definitions/app-webhook/definitions/level"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app-webhook/definitions/updated_at"
+        },
+        "url": {
+          "$ref": "#/definitions/app-webhook/definitions/url"
+        }
+      }
+    },
+    "add-on": {
+      "description": "Add-ons represent add-ons that have been provisioned and attached to one or more apps.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "title": "Heroku Platform API - Add-on",
+      "additionalProperties": false,
+      "required": [
+        "actions",
+        "addon_service",
+        "billing_entity",
+        "app",
+        "billed_price",
+        "config_vars",
+        "created_at",
+        "id",
+        "name",
+        "plan",
+        "provider_id",
+        "state",
+        "updated_at",
+        "web_url"
+      ],
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "actions": {
+          "description": "provider actions for this specific add-on",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": [
+              "object"
+            ]
+          },
+          "readOnly": true,
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/add-on-plan-action/definitions/id"
+            },
+            "label": {
+              "$ref": "#/definitions/add-on-plan-action/definitions/label"
+            },
+            "action": {
+              "$ref": "#/definitions/add-on-plan-action/definitions/action"
+            },
+            "url": {
+              "$ref": "#/definitions/add-on-plan-action/definitions/url"
+            },
+            "requires_owner": {
+              "$ref": "#/definitions/add-on-plan-action/definitions/requires_owner"
+            }
+          }
+        },
+        "cents": {
+          "description": "price in cents per unit of add-on",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "config": {
+          "additionalProperties": false,
+          "description": "custom add-on provisioning options",
+          "example": {
+            "db-version": "1.2.3"
+          },
+          "patternProperties": {
+            "^\\w+$": {
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "config_vars": {
+          "description": "config vars exposed to the owning app by this add-on",
+          "example": [
+            "FOO",
+            "BAZ"
+          ],
+          "items": {
+            "type": [
+              "string"
+            ]
+          },
+          "readOnly": true,
+          "type": [
+            "array"
+          ]
+        },
+        "confirm": {
+          "description": "name of billing entity for confirmation",
+          "example": "example",
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when add-on was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of add-on",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/add-on/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/add-on/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "globally unique name of the add-on",
+          "example": "acme-inc-primary-database",
+          "pattern": "^[a-zA-Z][A-Za-z0-9_-]+$",
+          "type": [
+            "string"
+          ]
+        },
+        "provider_id": {
+          "description": "id of this add-on with its provider",
+          "example": "abcd1234",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state in the add-on's lifecycle",
+          "enum": [
+            "provisioning",
+            "provisioned",
+            "deprovisioned"
+          ],
+          "example": "provisioned",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "unit": {
+          "description": "unit of price for add-on",
+          "example": "month",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when add-on was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "web_url": {
+          "description": "URL for logging into web interface of add-on (e.g. a dashboard)",
+          "example": "https://postgres.heroku.com/databases/01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uri",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "addon_service": {
+          "description": "identity of add-on service",
+          "anyOf": [
+            {
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/add-on-service/definitions/id"
+                },
+                "name": {
+                  "$ref": "#/definitions/add-on-service/definitions/name"
+                }
+              },
+              "strictProperties": true,
+              "type": [
+                "object"
+              ]
+            },
+            {
+              "$ref": "#/definitions/add-on-service"
+            }
+          ]
+        },
+        "plan": {
+          "description": "identity of add-on plan",
+          "anyOf": [
+            {
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/plan/definitions/id"
+                },
+                "name": {
+                  "$ref": "#/definitions/plan/definitions/name"
+                }
+              },
+              "strictProperties": true,
+              "type": [
+                "object"
+              ]
+            },
+            {
+              "$ref": "#/definitions/plan"
+            }
+          ]
+        },
+        "provision_message": {
+          "description": "A provision message",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List all existing add-ons.",
+          "href": "/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Info for an existing add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Create a new add-on.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "attachment": {
+                "description": "name for add-on's initial attachment",
+                "example": {
+                  "name": "DATABASE_FOLLOWER"
+                },
+                "properties": {
+                  "name": {
+                    "$ref": "#/definitions/add-on-attachment/definitions/name"
+                  }
+                },
+                "type": [
+                  "object"
+                ]
+              },
+              "config": {
+                "$ref": "#/definitions/add-on/definitions/config"
+              },
+              "confirm": {
+                "$ref": "#/definitions/add-on/definitions/confirm"
+              },
+              "plan": {
+                "$ref": "#/definitions/plan/definitions/identity"
+              },
+              "name": {
+                "$ref": "#/definitions/add-on/definitions/name"
+              }
+            },
+            "required": [
+              "plan"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing add-on.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for an existing add-on.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Info By App"
+        },
+        {
+          "description": "List existing add-ons for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By App"
+        },
+        {
+          "description": "Change add-on plan. Some add-ons may not support changing plans. In that case, an error will be returned.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/add-on/definitions/name"
+              },
+              "plan": {
+                "$ref": "#/definitions/plan/definitions/identity"
+              }
+            },
+            "required": [
+              "plan"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "List all existing add-ons a user has access to",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By User"
+        },
+        {
+          "description": "List add-ons used across all Team apps",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
+        },
+        {
+          "description": "Resolve an add-on from a name, optionally passing an app name. If there are matches it returns at least one add-on (exact match) or many.",
+          "href": "/actions/addons/resolve",
+          "method": "POST",
+          "rel": "resolve",
+          "schema": {
+            "properties": {
+              "addon": {
+                "$ref": "#/definitions/add-on/definitions/name"
+              },
+              "app": {
+                "$ref": "#/definitions/app/definitions/name"
+              },
+              "addon_service": {
+                "$ref": "#/definitions/add-on-service/definitions/name"
+              }
+            },
+            "required": [
+              "addon"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Resolution"
+        }
+      ],
+      "properties": {
+        "actions": {
+          "$ref": "#/definitions/add-on/definitions/actions"
+        },
+        "addon_service": {
+          "$ref": "#/definitions/add-on/definitions/addon_service"
+        },
+        "billing_entity": {
+          "description": "billing entity associated with this add-on",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "description": "unique identifier of the billing entity",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "name": {
+              "description": "name of the billing entity",
+              "example": "example",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "type": {
+              "description": "type of Object of the billing entity; new types allowed at any time.",
+              "enum": [
+                "app",
+                "team"
+              ],
+              "example": "app",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "strictProperties": true
+        },
+        "app": {
+          "description": "billing application associated with this add-on",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          },
+          "strictProperties": true
+        },
+        "billed_price": {
+          "description": "billed price",
+          "properties": {
+            "cents": {
+              "$ref": "#/definitions/plan/definitions/cents"
+            },
+            "contract": {
+              "$ref": "#/definitions/plan/definitions/contract"
+            },
+            "unit": {
+              "$ref": "#/definitions/plan/definitions/unit"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "config_vars": {
+          "$ref": "#/definitions/add-on/definitions/config_vars"
+        },
+        "created_at": {
+          "$ref": "#/definitions/add-on/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/add-on/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/add-on/definitions/name"
+        },
+        "plan": {
+          "$ref": "#/definitions/add-on/definitions/plan"
+        },
+        "provider_id": {
+          "$ref": "#/definitions/add-on/definitions/provider_id"
+        },
+        "provision_message": {
+          "$ref": "#/definitions/add-on/definitions/provision_message"
+        },
+        "state": {
+          "$ref": "#/definitions/add-on/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/add-on/definitions/updated_at"
+        },
+        "web_url": {
+          "$ref": "#/definitions/add-on/definitions/web_url"
+        }
+      }
+    },
+    "allowed-add-on-service": {
+      "description": "Entities that have been allowed to be used by a Team",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Allowed Add-on Service",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "added_at": {
+          "description": "when the add-on service was allowed",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "added_by": {
+          "description": "the user which allowed the add-on service",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "readOnly": true,
+          "type": [
+            "object"
+          ]
+        },
+        "addon_service": {
+          "description": "the add-on service allowed for use",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/add-on-service/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/add-on-service/definitions/name"
+            },
+            "human_name": {
+              "$ref": "#/definitions/add-on-service/definitions/human_name"
+            }
+          },
+          "readOnly": true,
+          "type": [
+            "object"
+          ]
+        },
+        "id": {
+          "description": "unique identifier for this allowed add-on service record",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/allowed-add-on-service/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/add-on-service/definitions/name"
+            }
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List all allowed add-on services for a team",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/allowed-addon-services",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/allowed-add-on-service"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
+        },
+        {
+          "description": "Allow an Add-on Service",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/allowed-addon-services",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "addon_service": {
+                "description": "name of the add-on service to allow",
+                "example": "heroku-postgresql",
+                "type": [
+                  "string"
+                ]
+              }
+            }
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/allowed-add-on-service"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Create By Team"
+        },
+        {
+          "description": "Remove an allowed add-on service",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/allowed-addon-services/{(%23%2Fdefinitions%2Fallowed-add-on-service%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/allowed-add-on-service"
+          },
+          "title": "Delete By Team"
+        }
+      ],
+      "properties": {
+        "added_at": {
+          "$ref": "#/definitions/allowed-add-on-service/definitions/added_at"
+        },
+        "added_by": {
+          "$ref": "#/definitions/allowed-add-on-service/definitions/added_by"
+        },
+        "addon_service": {
+          "$ref": "#/definitions/allowed-add-on-service/definitions/addon_service"
+        },
+        "id": {
+          "$ref": "#/definitions/allowed-add-on-service/definitions/id"
+        }
+      }
+    },
+    "app-feature": {
+      "description": "An app feature represents a Heroku labs capability that can be enabled or disabled for an app on Heroku.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - App Feature",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when app feature was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of app feature",
+          "example": "Causes app to example.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "doc_url": {
+          "description": "documentation URL of app feature",
+          "example": "http://devcenter.heroku.com/articles/example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "enabled": {
+          "description": "whether or not app feature has been enabled",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of app feature",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app-feature/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/app-feature/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of app feature",
+          "example": "name",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state of app feature",
+          "example": "public",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when app feature was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "display_name": {
+          "description": "user readable feature name",
+          "example": "My Feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "feedback_email": {
+          "description": "e-mail to send feedback about the feature",
+          "example": "feedback@heroku.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for an existing app feature.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Fapp-feature%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-feature"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing app features.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/features",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-feature"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update an existing app feature.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Fapp-feature%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "enabled": {
+                "$ref": "#/definitions/app-feature/definitions/enabled"
+              }
+            },
+            "required": [
+              "enabled"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/app-feature"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/app-feature/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/app-feature/definitions/description"
+        },
+        "doc_url": {
+          "$ref": "#/definitions/app-feature/definitions/doc_url"
+        },
+        "enabled": {
+          "$ref": "#/definitions/app-feature/definitions/enabled"
+        },
+        "id": {
+          "$ref": "#/definitions/app-feature/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/app-feature/definitions/name"
+        },
+        "state": {
+          "$ref": "#/definitions/app-feature/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app-feature/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/app-feature/definitions/display_name"
+        },
+        "feedback_email": {
+          "$ref": "#/definitions/app-feature/definitions/feedback_email"
+        }
+      }
+    },
+    "app-setup": {
+      "description": "An app setup represents an app on Heroku that is setup using an environment, addons, and scripts described in an app.json manifest file.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Setup API - App Setup",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of app setup",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "type": [
+            "string"
+          ],
+          "format": "uuid"
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app-setup/definitions/id"
+            }
+          ]
+        },
+        "buildpack_override": {
+          "description": "a buildpack override",
+          "properties": {
+            "url": {
+              "description": "location of the buildpack",
+              "example": "https://example.com/buildpack.tgz",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "description": "when app setup was created",
+          "example": "2012-01-01T12:00:00Z",
+          "readOnly": true,
+          "type": [
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "updated_at": {
+          "description": "when app setup was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "readOnly": true,
+          "type": [
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "status": {
+          "description": "the overall status of app setup",
+          "example": "failed",
+          "enum": [
+            "failed",
+            "pending",
+            "succeeded"
+          ],
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "resolved_success_url": {
+          "description": "fully qualified success url",
+          "example": "https://example.herokuapp.com/welcome",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "failure_message": {
+          "description": "reason that app setup has failed",
+          "example": "invalid app.json",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "manifest_errors": {
+          "description": "errors associated with invalid app.json manifest file",
+          "example": [
+            "config var FOO is required"
+          ],
+          "readOnly": true,
+          "items": {
+            "type": [
+              "string"
+            ]
+          },
+          "type": [
+            "array"
+          ]
+        },
+        "overrides": {
+          "description": "overrides of keys in the app.json manifest file",
+          "example": {
+            "buildpacks": [
+              {
+                "url": "https://example.com/buildpack.tgz"
+              }
+            ],
+            "env": {
+              "FOO": "bar",
+              "BAZ": "qux"
+            }
+          },
+          "properties": {
+            "buildpacks": {
+              "description": "overrides the buildpacks specified in the app.json manifest file",
+              "example": [
+                {
+                  "url": "https://example.com/buildpack.tgz"
+                }
+              ],
+              "items": {
+                "$ref": "#/definitions/app-setup/definitions/buildpack_override"
+              },
+              "type": [
+                "array"
+              ]
+            },
+            "env": {
+              "description": "overrides of the env specified in the app.json manifest file",
+              "example": {
+                "FOO": "bar",
+                "BAZ": "qux"
+              },
+              "readOnly": true,
+              "additionalProperties": false,
+              "patternProperties": {
+                "^\\w+$": {
+                  "type": [
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "postdeploy": {
+          "description": "result of postdeploy script",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "output": {
+              "description": "output of the postdeploy script",
+              "example": "assets precompiled",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "exit_code": {
+              "description": "The exit code of the postdeploy script",
+              "example": 1,
+              "readOnly": true,
+              "type": [
+                "integer"
+              ]
+            }
+          },
+          "readOnly": true
+        }
+      },
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/app-setup/definitions/id"
+        },
+        "created_at": {
+          "$ref": "#/definitions/app-setup/definitions/created_at"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app-setup/definitions/updated_at"
+        },
+        "status": {
+          "$ref": "#/definitions/app-setup/definitions/status"
+        },
+        "failure_message": {
+          "$ref": "#/definitions/app-setup/definitions/failure_message"
+        },
+        "app": {
+          "description": "identity of app",
+          "strictProperties": true,
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          }
+        },
+        "build": {
+          "description": "identity and status of build",
+          "strictProperties": true,
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/build/definitions/id"
+            },
+            "status": {
+              "$ref": "#/definitions/build/definitions/status"
+            },
+            "output_stream_url": {
+              "$ref": "#/definitions/build/definitions/output_stream_url"
+            }
+          }
+        },
+        "manifest_errors": {
+          "$ref": "#/definitions/app-setup/definitions/manifest_errors"
+        },
+        "postdeploy": {
+          "$ref": "#/definitions/app-setup/definitions/postdeploy"
+        },
+        "resolved_success_url": {
+          "$ref": "#/definitions/app-setup/definitions/resolved_success_url"
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new app setup from a gzipped tar archive containing an app.json manifest file.",
+          "title": "Create",
+          "rel": "create",
+          "method": "POST",
+          "href": "/app-setups",
+          "schema": {
+            "required": [
+              "source_blob"
+            ],
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "app": {
+                "description": "optional parameters for created app",
+                "properties": {
+                  "locked": {
+                    "$ref": "#/definitions/team-app/definitions/locked"
+                  },
+                  "name": {
+                    "$ref": "#/definitions/app/definitions/name"
+                  },
+                  "organization": {
+                    "$ref": "#/definitions/team/definitions/name"
+                  },
+                  "personal": {
+                    "$ref": "#/definitions/team-app/definitions/personal"
+                  },
+                  "region": {
+                    "$ref": "#/definitions/region/definitions/name"
+                  },
+                  "space": {
+                    "$ref": "#/definitions/space/definitions/name"
+                  },
+                  "stack": {
+                    "$ref": "#/definitions/stack/definitions/name"
+                  }
+                },
+                "type": [
+                  "object"
+                ]
+              },
+              "source_blob": {
+                "description": "gzipped tarball of source code containing app.json manifest file",
+                "properties": {
+                  "checksum": {
+                    "description": "an optional checksum of the gzipped tarball for verifying its integrity",
+                    "example": "SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                    "readOnly": true,
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "url": {
+                    "description": "URL of gzipped tarball of source code containing app.json manifest file",
+                    "example": "https://example.com/source.tgz?token=xyz",
+                    "readOnly": true,
+                    "type": [
+                      "string"
+                    ]
+                  },
+                  "version": {
+                    "description": "Version of the gzipped tarball.",
+                    "example": "v1.3.0",
+                    "readOnly": true,
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "type": [
+                  "object"
+                ]
+              },
+              "overrides": {
+                "$ref": "#/definitions/app-setup/definitions/overrides"
+              }
+            }
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/app-setup"
+          }
+        },
+        {
+          "description": "Get the status of an app setup.",
+          "title": "Info",
+          "rel": "self",
+          "method": "GET",
+          "href": "/app-setups/{(%23%2Fdefinitions%2Fapp-setup%2Fdefinitions%2Fidentity)}",
+          "targetSchema": {
+            "$ref": "#/definitions/app-setup"
+          }
+        }
+      ]
+    },
+    "app-transfer": {
+      "description": "An app transfer represents a two party interaction for transferring ownership of an app.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - App Transfer",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when app transfer was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of app transfer",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app-transfer/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          ]
+        },
+        "silent": {
+          "default": false,
+          "description": "whether to suppress email notification when transferring apps",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "state": {
+          "description": "the current state of an app transfer",
+          "enum": [
+            "pending",
+            "accepted",
+            "declined"
+          ],
+          "example": "pending",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when app transfer was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new app transfer.",
+          "href": "/account/app-transfers",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "app": {
+                "$ref": "#/definitions/app/definitions/identity"
+              },
+              "recipient": {
+                "$ref": "#/definitions/account/definitions/identity"
+              },
+              "silent": {
+                "$ref": "#/definitions/app-transfer/definitions/silent"
+              }
+            },
+            "required": [
+              "app",
+              "recipient"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/app-transfer"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing app transfer",
+          "href": "/account/app-transfers/{(%23%2Fdefinitions%2Fapp-transfer%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/app-transfer"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for existing app transfer.",
+          "href": "/account/app-transfers/{(%23%2Fdefinitions%2Fapp-transfer%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-transfer"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing apps transfers.",
+          "href": "/account/app-transfers",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-transfer"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update an existing app transfer.",
+          "href": "/account/app-transfers/{(%23%2Fdefinitions%2Fapp-transfer%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "state": {
+                "$ref": "#/definitions/app-transfer/definitions/state"
+              }
+            },
+            "required": [
+              "state"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/app-transfer"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "app involved in the transfer",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/app-transfer/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/app-transfer/definitions/id"
+        },
+        "owner": {
+          "description": "identity of the owner of the transfer",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "recipient": {
+          "description": "identity of the recipient of the transfer",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "state": {
+          "$ref": "#/definitions/app-transfer/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app-transfer/definitions/updated_at"
+        }
+      }
+    },
+    "app-webhook-delivery": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - App Webhook Delivery",
+      "description": "Represents the delivery of a webhook notification, including its current status.",
+      "stability": "production",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "attempt_id": {
+          "description": "unique identifier of attempt",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "attempt_error_class": {
+          "description": "error class encountered during attempt",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "attempt_code": {
+          "description": "http response code received during attempt",
+          "readOnly": true,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "attempt_created_at": {
+          "description": "when attempt was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "attempt_updated_at": {
+          "description": "when attempt was updated",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "attempt_status": {
+          "description": "status of an attempt",
+          "enum": [
+            "scheduled",
+            "succeeded",
+            "failed"
+          ],
+          "example": "scheduled",
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when the delivery was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "the delivery's unique identifier",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "num_attempts": {
+          "description": "number of times a delivery has been attempted",
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/id"
+            }
+          ]
+        },
+        "next_attempt_at": {
+          "description": "when delivery will be attempted again",
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "description": "the delivery's status",
+          "enum": [
+            "pending",
+            "scheduled",
+            "retrying",
+            "failed",
+            "succeeded"
+          ],
+          "example": "pending",
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the delivery was last updated",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Returns the info for an existing delivery.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhook-deliveries/{(%23%2Fdefinitions%2Fapp-webhook-delivery%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook-delivery"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Lists existing deliveries for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhook-deliveries",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-webhook-delivery"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/created_at"
+        },
+        "event": {
+          "description": "identity of event",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app-webhook-event/definitions/id"
+            },
+            "include": {
+              "$ref": "#/definitions/app-webhook-event/definitions/include"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/id"
+        },
+        "num_attempts": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/num_attempts"
+        },
+        "next_attempt_at": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/next_attempt_at"
+        },
+        "last_attempt": {
+          "description": "last attempt of a delivery",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_id"
+            },
+            "code": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_code"
+            },
+            "error_class": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_error_class"
+            },
+            "status": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_status"
+            },
+            "created_at": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_created_at"
+            },
+            "updated_at": {
+              "$ref": "#/definitions/app-webhook-delivery/definitions/attempt_updated_at"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/status"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app-webhook-delivery/definitions/updated_at"
+        },
+        "webhook": {
+          "description": "identity of webhook",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app-webhook/definitions/id"
+            },
+            "level": {
+              "$ref": "#/definitions/app-webhook/definitions/level"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "app-webhook-event": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - App Webhook Event",
+      "description": "Represents a webhook event that occurred.",
+      "stability": "production",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "action": {
+          "description": "the type of event that occurred",
+          "example": "create",
+          "type": [
+            "string"
+          ]
+        },
+        "actor": {
+          "description": "user that caused event",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "description": "when event was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "data": {
+          "description": "the current details of the event",
+          "type": [
+            "object"
+          ]
+        },
+        "id": {
+          "description": "the event's unique identifier",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app-webhook-event/definitions/id"
+            }
+          ]
+        },
+        "include": {
+          "description": "the type of entity that the event is related to",
+          "example": "api:release",
+          "type": [
+            "string"
+          ]
+        },
+        "payload": {
+          "description": "payload of event",
+          "properties": {
+            "action": {
+              "$ref": "#/definitions/app-webhook-event/definitions/action"
+            },
+            "actor": {
+              "$ref": "#/definitions/app-webhook-event/definitions/actor"
+            },
+            "data": {
+              "$ref": "#/definitions/app-webhook-event/definitions/data"
+            },
+            "previous_data": {
+              "$ref": "#/definitions/app-webhook-event/definitions/previous_data"
+            },
+            "resource": {
+              "$ref": "#/definitions/app-webhook-event/definitions/resource"
+            },
+            "version": {
+              "$ref": "#/definitions/app-webhook-event/definitions/version"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "previous_data": {
+          "description": "previous details of the event (if any)",
+          "type": [
+            "object"
+          ]
+        },
+        "resource": {
+          "description": "the type of resource associated with the event",
+          "example": "release",
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the event was last updated",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "version": {
+          "description": "the version of the details provided for the event",
+          "example": "1",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Returns the info for a specified webhook event.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhook-events/{(%23%2Fdefinitions%2Fapp-webhook-event%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook-event"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Lists existing webhook events for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhook-events",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-webhook-event"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/app-webhook-event/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/app-webhook-event/definitions/id"
+        },
+        "include": {
+          "$ref": "#/definitions/app-webhook-event/definitions/include"
+        },
+        "payload": {
+          "$ref": "#/definitions/app-webhook-event/definitions/payload"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app-webhook-event/definitions/updated_at"
+        }
+      }
+    },
+    "app-webhook": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - App Webhook",
+      "description": "Represents the details of a webhook subscription",
+      "stability": "production",
+      "strictProperties": false,
+      "additionalProperties": false,
+      "required": [
+        "created_at",
+        "id",
+        "include",
+        "level",
+        "updated_at",
+        "url"
+      ],
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "authorization": {
+          "description": "a custom `Authorization` header that Heroku will include with all webhook notifications",
+          "example": "Bearer 9266671b2767f804c9d5809c2d384ed57d8f8ce1abd1043e1fb3fbbcb8c3",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when the webhook was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "the webhook's unique identifier",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "include": {
+          "description": "the entities that the subscription provides notifications for",
+          "items": {
+            "example": "api:release",
+            "type": [
+              "string"
+            ]
+          },
+          "type": [
+            "array"
+          ]
+        },
+        "level": {
+          "description": "if `notify`, Heroku makes a single, fire-and-forget delivery attempt. If `sync`, Heroku attempts multiple deliveries until the request is successful or a limit is reached",
+          "enum": [
+            "notify",
+            "sync"
+          ],
+          "example": "notify",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app-webhook/definitions/id"
+            }
+          ]
+        },
+        "secret": {
+          "description": "a value that Heroku will use to sign all webhook notification requests (the signature is included in the request’s `Heroku-Webhook-Hmac-SHA256` header)",
+          "example": "dcbff0c4430a2960a2552389d587bc58d30a37a8cf3f75f8fb77abe667ad",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the webhook was updated",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "url": {
+          "description": "the URL where the webhook's notification requests are sent",
+          "format": "uri",
+          "type": [
+            "string"
+          ]
+        },
+        "app_webhook": {
+          "properties": {
+            "app": {
+              "description": "identity of app. Only used for customer webhooks.",
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/app/definitions/id"
+                },
+                "name": {
+                  "$ref": "#/definitions/app/definitions/name"
+                }
+              },
+              "strictProperties": true,
+              "type": [
+                "object"
+              ]
+            },
+            "created_at": {
+              "$ref": "#/definitions/app-webhook/definitions/created_at"
+            },
+            "id": {
+              "$ref": "#/definitions/app-webhook/definitions/id"
+            },
+            "include": {
+              "$ref": "#/definitions/app-webhook/definitions/include"
+            },
+            "level": {
+              "$ref": "#/definitions/app-webhook/definitions/level"
+            },
+            "updated_at": {
+              "$ref": "#/definitions/app-webhook/definitions/updated_at"
+            },
+            "url": {
+              "$ref": "#/definitions/app-webhook/definitions/url"
+            }
+          },
+          "description": "app webhook",
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create an app webhook subscription.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhooks",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "authorization": {
+                "$ref": "#/definitions/app-webhook/definitions/authorization"
+              },
+              "include": {
+                "$ref": "#/definitions/app-webhook/definitions/include"
+              },
+              "level": {
+                "$ref": "#/definitions/app-webhook/definitions/level"
+              },
+              "secret": {
+                "$ref": "#/definitions/app-webhook/definitions/secret"
+              },
+              "url": {
+                "$ref": "#/definitions/app-webhook/definitions/url"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "include",
+              "level",
+              "url"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook/definitions/app_webhook"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Removes an app webhook subscription.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook/definitions/app_webhook"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Returns the info for an app webhook subscription.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook/definitions/app_webhook"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List all webhook subscriptions for a particular app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhooks",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app-webhook/definitions/app_webhook"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Updates the details of an app webhook subscription.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/webhooks/{(%23%2Fdefinitions%2Fapp-webhook%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "authorization": {
+                "$ref": "#/definitions/app-webhook/definitions/authorization"
+              },
+              "include": {
+                "$ref": "#/definitions/app-webhook/definitions/include"
+              },
+              "level": {
+                "$ref": "#/definitions/app-webhook/definitions/level"
+              },
+              "secret": {
+                "$ref": "#/definitions/app-webhook/definitions/secret"
+              },
+              "url": {
+                "$ref": "#/definitions/app-webhook/definitions/url"
+              }
+            },
+            "strictProperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/app-webhook/definitions/app_webhook"
+          },
+          "title": "Update"
+        }
+      ]
+    },
+    "app": {
+      "description": "An app represents the program that you would like to deploy and run on Heroku.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - App",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "archived_at": {
+          "description": "when app was archived",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "buildpack_provided_description": {
+          "description": "description from buildpack of app",
+          "example": "Ruby/Rack",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when app was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "generation": {
+          "description": "Generation of the Heroku platform for this app",
+          "readOnly": true,
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "description": "unique identifier of the generation of the Heroku platform for this app",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "name": {
+              "description": "unique name of the generation of the Heroku platform for this app",
+              "example": "cedar",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "git_url": {
+          "description": "git repo URL of app",
+          "example": "https://git.heroku.com/example.git",
+          "pattern": "^https://git\\.heroku\\.com/[a-z][a-z0-9-]{2,29}\\.git$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of app",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          ]
+        },
+        "maintenance": {
+          "default": false,
+          "description": "maintenance status of app",
+          "example": false,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "name": {
+          "description": "unique name of app",
+          "example": "example",
+          "pattern": "^[a-z][a-z0-9-]{1,28}[a-z0-9]$",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "released_at": {
+          "default": null,
+          "description": "when app was released",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "repo_size": {
+          "default": null,
+          "description": "git repo size in bytes of app",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "slug_size": {
+          "default": null,
+          "description": "slug size in bytes of app",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "updated_at": {
+          "description": "when app was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "web_url": {
+          "description": "web URL of app",
+          "example": "https://example.herokuapp.com/",
+          "format": "uri",
+          "pattern": "^https?://[a-z][a-z0-9-]{3,43}\\.herokuapp\\.com/$",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "acm": {
+          "description": "ACM status of this app",
+          "default": false,
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new app.",
+          "href": "/apps",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/app/definitions/name"
+              },
+              "region": {
+                "$ref": "#/definitions/region/definitions/identity"
+              },
+              "stack": {
+                "$ref": "#/definitions/stack/definitions/identity"
+              },
+              "feature_flags": {
+                "description": "unique name of app feature",
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/app-feature/definitions/name"
+                }
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/app"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/app"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for existing app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/app"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing apps.",
+          "href": "/apps",
+          "method": "GET",
+          "ranges": [
+            "id",
+            "name",
+            "updated_at"
+          ],
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List owned and collaborated apps (excludes team apps).",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/apps",
+          "method": "GET",
+          "ranges": [
+            "id",
+            "name",
+            "updated_at"
+          ],
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List Owned and Collaborated"
+        },
+        {
+          "description": "Update an existing app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "build_stack": {
+                "$ref": "#/definitions/stack/definitions/identity"
+              },
+              "maintenance": {
+                "$ref": "#/definitions/app/definitions/maintenance"
+              },
+              "name": {
+                "$ref": "#/definitions/app/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/app"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Enable ACM flag for an app",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/acm",
+          "method": "POST",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/app"
+          },
+          "title": "Enable ACM"
+        },
+        {
+          "description": "Disable ACM flag for an app",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/acm",
+          "method": "DELETE",
+          "rel": "delete",
+          "targetSchema": {
+            "$ref": "#/definitions/app"
+          },
+          "title": "Disable ACM"
+        },
+        {
+          "description": "Refresh ACM for an app",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/acm",
+          "method": "PATCH",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/app"
+          },
+          "title": "Refresh ACM"
+        }
+      ],
+      "properties": {
+        "acm": {
+          "$ref": "#/definitions/app/definitions/acm"
+        },
+        "archived_at": {
+          "$ref": "#/definitions/app/definitions/archived_at"
+        },
+        "buildpack_provided_description": {
+          "$ref": "#/definitions/app/definitions/buildpack_provided_description"
+        },
+        "build_stack": {
+          "description": "identity of the stack that will be used for new builds",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/app/definitions/created_at"
+        },
+        "generation": {
+          "$ref": "#/definitions/app/definitions/generation"
+        },
+        "git_url": {
+          "$ref": "#/definitions/app/definitions/git_url"
+        },
+        "id": {
+          "$ref": "#/definitions/app/definitions/id"
+        },
+        "internal_routing": {
+          "$ref": "#/definitions/team-app/definitions/internal_routing"
+        },
+        "maintenance": {
+          "$ref": "#/definitions/app/definitions/maintenance"
+        },
+        "name": {
+          "$ref": "#/definitions/app/definitions/name"
+        },
+        "owner": {
+          "description": "identity of app owner",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "organization": {
+          "description": "identity of team",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "team": {
+          "description": "identity of team",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "region": {
+          "description": "identity of app region",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/region/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/region/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "released_at": {
+          "$ref": "#/definitions/app/definitions/released_at"
+        },
+        "repo_size": {
+          "$ref": "#/definitions/app/definitions/repo_size"
+        },
+        "slug_size": {
+          "$ref": "#/definitions/app/definitions/slug_size"
+        },
+        "space": {
+          "description": "identity of space",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/space/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/space/definitions/name"
+            },
+            "shield": {
+              "$ref": "#/definitions/space/definitions/shield"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "stack": {
+          "description": "identity of app stack",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app/definitions/updated_at"
+        },
+        "web_url": {
+          "$ref": "#/definitions/app/definitions/web_url"
+        }
+      }
+    },
+    "archive": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - Audit Trail Archive",
+      "description": "An audit trail archive represents a monthly json zipped file containing events",
+      "stability": "production",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of enterprise_account",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/archive/definitions/id"
+        },
+        "month": {
+          "description": "month of the archive",
+          "enum": [
+            "01",
+            "02",
+            "03",
+            "04",
+            "05",
+            "06",
+            "07",
+            "08",
+            "09",
+            "10",
+            "11",
+            "12"
+          ],
+          "example": "10",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "year": {
+          "description": "year of the archive",
+          "example": 2019,
+          "readOnly": true,
+          "minimum": 2017,
+          "type": [
+            "integer"
+          ]
+        },
+        "created_at": {
+          "description": "when archive was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "url": {
+          "description": "url where to download the archive",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "checksum": {
+          "description": "checksum for the archive",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "size": {
+          "description": "size of the archive in bytes",
+          "example": 100,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get archive for a single month.",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}/archives/{(%23%2Fdefinitions%2Farchive%2Fdefinitions%2Fyear)}/{(%23%2Fdefinitions%2Farchive%2Fdefinitions%2Fmonth)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "List existing archives.",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}/archives",
+          "method": "GET",
+          "rel": "instances",
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/archive/definitions/created_at"
+        },
+        "month": {
+          "$ref": "#/definitions/archive/definitions/month"
+        },
+        "year": {
+          "$ref": "#/definitions/archive/definitions/year"
+        },
+        "url": {
+          "$ref": "#/definitions/archive/definitions/url"
+        },
+        "checksum": {
+          "$ref": "#/definitions/archive/definitions/checksum"
+        },
+        "size": {
+          "$ref": "#/definitions/archive/definitions/size"
+        }
+      }
+    },
+    "audit-trail-event": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - Audit Trail Event",
+      "description": "An audit trail event represents some action on the platform",
+      "stability": "production",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of event",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "type of event",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "action": {
+          "description": "action for the event",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "actor": {
+          "description": "user who caused event",
+          "readOnly": true,
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "format": "uuid",
+              "type": [
+                "string"
+              ]
+            },
+            "email": {
+              "format": "email",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "app": {
+          "description": "app upon which event took place",
+          "readOnly": true,
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "format": "uuid",
+              "type": [
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "owner": {
+          "description": "owner of the app targeted by the event",
+          "readOnly": true,
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "format": "uuid",
+              "type": [
+                "string"
+              ]
+            },
+            "email": {
+              "format": "email",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "enterprise_account": {
+          "description": "enterprise account on which the event happened",
+          "readOnly": true,
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "format": "uuid",
+              "type": [
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "team": {
+          "description": "team on which the event happened",
+          "readOnly": true,
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "format": "uuid",
+              "type": [
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "request": {
+          "description": "information about where the action was triggered",
+          "readOnly": true,
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "ip_address": {
+              "format": "ipv4",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "data": {
+          "description": "data specific to the event",
+          "readOnly": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "description": "when event was created",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List existing events. Returns all events for one day, defaulting to current day. Order, actor, action, and type, and day query params can be specified as query parameters. For example, '/enterprise-accounts/:id/events?order=desc&actor=user@example.com&action=create&type=app&day=2020-09-30' would return events in descending order and only return app created events by the user with user@example.com email address.",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}/events",
+          "method": "GET",
+          "rel": "instances",
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/audit-trail-event/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/audit-trail-event/definitions/id"
+        },
+        "type": {
+          "$ref": "#/definitions/audit-trail-event/definitions/type"
+        },
+        "action": {
+          "$ref": "#/definitions/audit-trail-event/definitions/action"
+        },
+        "actor": {
+          "$ref": "#/definitions/audit-trail-event/definitions/actor"
+        },
+        "app": {
+          "$ref": "#/definitions/audit-trail-event/definitions/app"
+        },
+        "owner": {
+          "$ref": "#/definitions/audit-trail-event/definitions/owner"
+        },
+        "enterprise_account": {
+          "$ref": "#/definitions/audit-trail-event/definitions/enterprise_account"
+        },
+        "team": {
+          "$ref": "#/definitions/audit-trail-event/definitions/team"
+        },
+        "request": {
+          "$ref": "#/definitions/audit-trail-event/definitions/request"
+        },
+        "data": {
+          "$ref": "#/definitions/audit-trail-event/definitions/data"
+        }
+      }
+    },
+    "build": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A build represents the process of transforming a code tarball into build artifacts",
+      "title": "Heroku Build API - Build",
+      "stability": "production",
+      "strictProperties": false,
+      "required": [
+        "created_at",
+        "id",
+        "source_blob",
+        "status",
+        "updated_at",
+        "user"
+      ],
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "buildpacks": {
+          "description": "buildpacks executed for this build, in order (only applicable to Cedar-generation apps)",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "Buildpack to execute in a build",
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "url": {
+                "description": "the URL of the buildpack for the app",
+                "example": "https://github.com/heroku/heroku-buildpack-ruby",
+                "readOnly": false,
+                "type": [
+                  "string"
+                ]
+              },
+              "name": {
+                "description": "Buildpack Registry name of the buildpack for the app",
+                "example": "heroku/ruby",
+                "readOnly": false,
+                "type": [
+                  "string"
+                ]
+              }
+            }
+          }
+        },
+        "created_at": {
+          "description": "when build was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of build",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/build/definitions/id"
+            }
+          ]
+        },
+        "output_stream_url": {
+          "description": "Build process output will be available from this URL as a stream. The stream is available as either `text/plain` or `text/event-stream`. Clients should be prepared to handle disconnects and can resume the stream by sending a `Range` header (for `text/plain`) or a `Last-Event-Id` header (for `text/event-stream`).",
+          "example": "https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "release": {
+          "description": "release resulting from the build",
+          "strictProperties": true,
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/release/definitions/id"
+            }
+          },
+          "example": {
+            "id": "01234567-89ab-cdef-0123-456789abcdef"
+          },
+          "readOnly": true,
+          "type": [
+            "null",
+            "object"
+          ],
+          "definitions": {
+            "id": {
+              "description": "unique identifier of release",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "source_blob": {
+          "description": "location of gzipped tarball of source code used to create build",
+          "properties": {
+            "checksum": {
+              "description": "an optional checksum of the gzipped tarball for verifying its integrity",
+              "example": "SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "readOnly": true,
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "url": {
+              "description": "URL where gzipped tar archive of source code for build was downloaded.",
+              "example": "https://example.com/source.tgz?token=xyz",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "version": {
+              "description": "Version of the gzipped tarball.",
+              "example": "v1.3.0",
+              "readOnly": true,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "version_description": {
+              "description": "Version description of the gzipped tarball.",
+              "example": "* Fake User: Change session key",
+              "readOnly": true,
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "stack": {
+          "description": "stack of build",
+          "example": "heroku-22",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "status": {
+          "description": "status of build",
+          "enum": [
+            "failed",
+            "pending",
+            "succeeded"
+          ],
+          "example": "succeeded",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when build was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new build.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/builds",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "buildpacks": {
+                "$ref": "#/definitions/build/definitions/buildpacks"
+              },
+              "source_blob": {
+                "$ref": "#/definitions/build/definitions/source_blob"
+              }
+            },
+            "required": [
+              "source_blob"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/build"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Info for existing build.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/builds/{(%23%2Fdefinitions%2Fbuild%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/build"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing build.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/builds",
+          "method": "GET",
+          "ranges": [
+            "id",
+            "started_at"
+          ],
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/build"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Destroy a build cache.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/build-cache",
+          "method": "DELETE",
+          "rel": "empty",
+          "title": "Delete cache"
+        },
+        {
+          "description": "Cancel running build.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/builds/{(%23%2Fdefinitions%2Fbuild%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/build"
+          },
+          "title": "Cancel"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "app that the build belongs to",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "buildpacks": {
+          "$ref": "#/definitions/build/definitions/buildpacks"
+        },
+        "created_at": {
+          "$ref": "#/definitions/build/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/build/definitions/id"
+        },
+        "output_stream_url": {
+          "$ref": "#/definitions/build/definitions/output_stream_url"
+        },
+        "source_blob": {
+          "$ref": "#/definitions/build/definitions/source_blob"
+        },
+        "release": {
+          "$ref": "#/definitions/build/definitions/release"
+        },
+        "slug": {
+          "description": "slug created by this build (only applicable for Cedar-generation apps)",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/slug/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "stack": {
+          "$ref": "#/definitions/build/definitions/stack"
+        },
+        "status": {
+          "$ref": "#/definitions/build/definitions/status"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/build/definitions/updated_at"
+        },
+        "user": {
+          "description": "user that started the build",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "buildpack-installation": {
+      "description": "A buildpack installation represents a buildpack that will be run against an app.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Buildpack Installations",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "ordinal": {
+          "description": "determines the order in which the buildpacks will execute",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "update": {
+          "additionalProperties": false,
+          "description": "Properties to update a buildpack installation",
+          "properties": {
+            "buildpack": {
+              "$ref": "#/definitions/buildpack-installation/definitions/url"
+            }
+          },
+          "readOnly": false,
+          "required": [
+            "buildpack"
+          ],
+          "type": [
+            "object"
+          ]
+        },
+        "url": {
+          "description": "location of the buildpack for the app. Either a url (unofficial buildpacks) or an internal urn (heroku official buildpacks).",
+          "example": "https://github.com/heroku/heroku-buildpack-ruby",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "either the Buildpack Registry name or a URL of the buildpack for the app",
+          "example": "heroku/ruby",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Update an app's buildpack installations.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/buildpack-installations",
+          "method": "PUT",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "updates": {
+                "description": "The buildpack attribute can accept a name, a url, or a urn.",
+                "items": {
+                  "$ref": "#/definitions/buildpack-installation/definitions/update"
+                },
+                "type": [
+                  "array"
+                ]
+              }
+            },
+            "required": [
+              "updates"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/buildpack-installation"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Update"
+        },
+        {
+          "description": "List an app's existing buildpack installations.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/buildpack-installations",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/buildpack-installation"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "ordinal": {
+          "$ref": "#/definitions/buildpack-installation/definitions/ordinal"
+        },
+        "buildpack": {
+          "description": "buildpack",
+          "properties": {
+            "url": {
+              "$ref": "#/definitions/buildpack-installation/definitions/url"
+            },
+            "name": {
+              "$ref": "#/definitions/buildpack-installation/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "collaborator": {
+      "description": "A collaborator represents an account that has been given access to an app on Heroku.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "additionalProperties": false,
+      "required": [
+        "app",
+        "created_at",
+        "id",
+        "updated_at",
+        "user"
+      ],
+      "stability": "production",
+      "title": "Heroku Platform API - Collaborator",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when collaborator was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "email": {
+          "description": "invited email address of collaborator",
+          "example": "collaborator@example.com",
+          "format": "email",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of collaborator",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/collaborator/definitions/email"
+            },
+            {
+              "$ref": "#/definitions/collaborator/definitions/id"
+            }
+          ]
+        },
+        "silent": {
+          "default": false,
+          "description": "whether to suppress email invitation when creating collaborator",
+          "example": false,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "updated_at": {
+          "description": "when collaborator was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new collaborator.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/collaborators",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "silent": {
+                "$ref": "#/definitions/collaborator/definitions/silent"
+              },
+              "user": {
+                "$ref": "#/definitions/account/definitions/identity"
+              }
+            },
+            "required": [
+              "user"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/collaborator"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing collaborator.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Fcollaborator%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/collaborator"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for existing collaborator.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Fcollaborator%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/collaborator"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing collaborators.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/collaborators",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/collaborator"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "app collaborator belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/collaborator/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/collaborator/definitions/id"
+        },
+        "permissions": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/team-app-permission"
+          }
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/collaborator/definitions/updated_at"
+        },
+        "user": {
+          "description": "identity of collaborated account",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "federated": {
+              "$ref": "#/definitions/account/definitions/federated"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "config-var": {
+      "description": "Config Vars allow you to manage the configuration information provided to an app on Heroku.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Config Vars",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "config_vars": {
+          "additionalProperties": false,
+          "description": "hash of config vars",
+          "example": {
+            "FOO": "bar",
+            "BAZ": "qux"
+          },
+          "patternProperties": {
+            "^\\w+$": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get config-vars for app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/config-vars",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/config-var/definitions/config_vars"
+          },
+          "title": "Info for App"
+        },
+        {
+          "description": "Get config-vars for a release.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/releases/{(%23%2Fdefinitions%2Frelease%2Fdefinitions%2Fidentity)}/config-vars",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/config-var/definitions/config_vars"
+          },
+          "title": "Info for App Release"
+        },
+        {
+          "description": "Update config-vars for app. You can update existing config-vars by setting them again, and remove by setting it to `null`.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/config-vars",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "additionalProperties": false,
+            "description": "hash of config changes – update values or delete by seting it to `null`",
+            "example": {
+              "FOO": "bar",
+              "BAZ": "qux"
+            },
+            "patternProperties": {
+              "^\\w+$": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/config-var/definitions/config_vars"
+          },
+          "title": "Update"
+        }
+      ],
+      "example": {
+        "FOO": "bar",
+        "BAZ": "qux"
+      },
+      "patternProperties": {
+        "^\\w+$": {
+          "type": [
+            "string"
+          ]
+        }
+      }
+    },
+    "credit": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A credit represents value that will be used up before further charges are assigned to an account.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Credit",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "amount": {
+          "description": "total value of credit in cents",
+          "example": 10000,
+          "type": [
+            "number"
+          ]
+        },
+        "balance": {
+          "description": "remaining value of credit in cents",
+          "example": 5000,
+          "type": [
+            "number"
+          ]
+        },
+        "created_at": {
+          "description": "when credit was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "expires_at": {
+          "description": "when credit will expire",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of credit",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/credit/definitions/id"
+            }
+          ]
+        },
+        "title": {
+          "description": "a name for credit",
+          "example": "gift card",
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when credit was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new credit.",
+          "href": "/account/credits",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "code1": {
+                "description": "first code from a discount card",
+                "example": "012abc",
+                "type": [
+                  "string"
+                ]
+              },
+              "code2": {
+                "description": "second code from a discount card",
+                "example": "012abc",
+                "type": [
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/credit"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Info for existing credit.",
+          "href": "/account/credits/{(%23%2Fdefinitions%2Fcredit%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/credit"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing credits.",
+          "href": "/account/credits",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/credit"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/credit/definitions/amount"
+        },
+        "balance": {
+          "$ref": "#/definitions/credit/definitions/balance"
+        },
+        "created_at": {
+          "$ref": "#/definitions/credit/definitions/created_at"
+        },
+        "expires_at": {
+          "$ref": "#/definitions/credit/definitions/expires_at"
+        },
+        "id": {
+          "$ref": "#/definitions/credit/definitions/id"
+        },
+        "title": {
+          "$ref": "#/definitions/credit/definitions/title"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/credit/definitions/updated_at"
+        }
+      }
+    },
+    "domain": {
+      "description": "Domains define what web routes should be routed to an app on Heroku.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Domain",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "acm_status": {
+          "description": "status of this record's ACM",
+          "example": "pending",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "acm_status_reason": {
+          "description": "reason for the status of this record's ACM",
+          "example": "Failing CCA check",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when domain was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "cname": {
+          "description": "canonical name record, the address to point a domain at",
+          "example": "example.herokudns.com",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "status": {
+          "description": "status of this record's cname",
+          "example": "pending",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "hostname": {
+          "description": "full hostname",
+          "example": "subdomain.example.com",
+          "format": "uri",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this domain",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/domain/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/domain/definitions/hostname"
+            }
+          ]
+        },
+        "kind": {
+          "description": "type of domain name",
+          "enum": [
+            "heroku",
+            "custom"
+          ],
+          "example": "custom",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when domain was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "sni_endpoint": {
+          "description": "null or unique identifier or name for SNI endpoint",
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new domain.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/domains",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "hostname": {
+                "$ref": "#/definitions/domain/definitions/hostname"
+              },
+              "sni_endpoint": {
+                "$ref": "#/definitions/domain/definitions/sni_endpoint"
+              }
+            },
+            "required": [
+              "hostname",
+              "sni_endpoint"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/domain"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Associate an SNI endpoint",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/domains/{(%23%2Fdefinitions%2Fdomain%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "sni_endpoint": {
+                "$ref": "#/definitions/domain/definitions/sni_endpoint"
+              }
+            },
+            "required": [
+              "sni_endpoint"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/domain"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Delete an existing domain",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/domains/{(%23%2Fdefinitions%2Fdomain%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/domain"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for existing domain.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/domains/{(%23%2Fdefinitions%2Fdomain%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/domain"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing domains.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/domains",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/domain"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "acm_status": {
+          "$ref": "#/definitions/domain/definitions/acm_status"
+        },
+        "acm_status_reason": {
+          "$ref": "#/definitions/domain/definitions/acm_status_reason"
+        },
+        "app": {
+          "description": "app that owns the domain",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "cname": {
+          "$ref": "#/definitions/domain/definitions/cname"
+        },
+        "created_at": {
+          "$ref": "#/definitions/domain/definitions/created_at"
+        },
+        "hostname": {
+          "$ref": "#/definitions/domain/definitions/hostname"
+        },
+        "id": {
+          "$ref": "#/definitions/domain/definitions/id"
+        },
+        "kind": {
+          "$ref": "#/definitions/domain/definitions/kind"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/domain/definitions/updated_at"
+        },
+        "status": {
+          "$ref": "#/definitions/domain/definitions/status"
+        },
+        "sni_endpoint": {
+          "description": "sni endpoint the domain is associated with",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/sni-endpoint/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/sni-endpoint/definitions/id"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        }
+      }
+    },
+    "dyno-size": {
+      "description": "Dyno sizes are the values and details of sizes that can be assigned to dynos. This information can also be found at : [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Dyno Size",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "architecture": {
+          "description": "CPU architecture of this dyno size",
+          "example": "amd64",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "compute": {
+          "description": "minimum vCPUs, non-dedicated may get more depending on load",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "dedicated": {
+          "description": "whether this dyno will be dedicated to one user",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "generation": {
+          "description": "Generation of the Heroku platform for this dyno size",
+          "readOnly": true,
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "description": "unique identifier of the generation of the Heroku platform for this dyno size",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "name": {
+              "description": "unique name of the generation of the Heroku platform for this dyno size",
+              "example": "cedar",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "id": {
+          "description": "unique identifier of the dyno size",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/dyno-size/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/dyno-size/definitions/name"
+            }
+          ]
+        },
+        "memory": {
+          "description": "amount of RAM in GB",
+          "example": 0.5,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "name": {
+          "description": "name of the dyno size",
+          "example": "eco",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "cost": {
+          "description": "price information for this dyno size",
+          "readOnly": true,
+          "type": [
+            "null",
+            "object"
+          ],
+          "definitions": {
+            "cents": {
+              "description": "price in cents per unit time",
+              "example": 0,
+              "readOnly": true,
+              "type": [
+                "integer"
+              ]
+            },
+            "unit": {
+              "description": "unit of price for dyno",
+              "readOnly": true,
+              "example": "month",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "precise_dyno_units": {
+          "description": "unit of consumption for Heroku Enterprise customers to 2 decimal places",
+          "example": 0.28,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "private_space_only": {
+          "description": "whether this dyno can only be provisioned in a private space",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing dyno size.",
+          "href": "/dyno-sizes/{(%23%2Fdefinitions%2Fdyno-size%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/dyno-size"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing dyno sizes.",
+          "href": "/dyno-sizes",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/dyno-size"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List available dyno sizes for an app",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/available-dyno-sizes",
+          "method": "GET",
+          "rel": "available-app-dynos",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/dyno-size"
+            }
+          },
+          "title": "List App Dyno Sizes"
+        }
+      ],
+      "properties": {
+        "architecture": {
+          "$ref": "#/definitions/dyno-size/definitions/architecture"
+        },
+        "compute": {
+          "$ref": "#/definitions/dyno-size/definitions/compute"
+        },
+        "cost": {
+          "$ref": "#/definitions/dyno-size/definitions/cost"
+        },
+        "dedicated": {
+          "$ref": "#/definitions/dyno-size/definitions/dedicated"
+        },
+        "precise_dyno_units": {
+          "$ref": "#/definitions/dyno-size/definitions/precise_dyno_units"
+        },
+        "generation": {
+          "$ref": "#/definitions/dyno-size/definitions/generation"
+        },
+        "id": {
+          "$ref": "#/definitions/dyno-size/definitions/id"
+        },
+        "memory": {
+          "$ref": "#/definitions/dyno-size/definitions/memory"
+        },
+        "name": {
+          "$ref": "#/definitions/dyno-size/definitions/name"
+        },
+        "private_space_only": {
+          "$ref": "#/definitions/dyno-size/definitions/private_space_only"
+        }
+      }
+    },
+    "dyno": {
+      "description": "Dynos encapsulate running processes of an app on Heroku. Detailed information about dyno sizes can be found at: [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Dyno",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "attach": {
+          "description": "whether to stream output or not",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "attach_url": {
+          "description": "a URL to stream output from for attached processes or null for non-attached processes",
+          "example": "rendezvous://rendezvous.runtime.heroku.com:5000/{rendezvous-id}",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "command": {
+          "description": "command used to start this process",
+          "example": "bash",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when dyno was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "env": {
+          "additionalProperties": false,
+          "description": "custom environment to add to the dyno config vars",
+          "example": {
+            "COLUMNS": "80",
+            "LINES": "24"
+          },
+          "patternProperties": {
+            "^\\w+$": {
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "readOnly": false,
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this dyno",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/dyno/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/dyno/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "the name of this process on this dyno",
+          "example": "run.1",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "formation_type": {
+          "description": "the formation type of this process on this dyno",
+          "example": "run",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "force_no_tty": {
+          "description": "force an attached one-off dyno to not run in a tty",
+          "example": null,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "size": {
+          "description": "dyno size",
+          "example": "standard-1X",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "current status of process (either: crashed, down, idle, starting, or up)",
+          "example": "up",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "type of process",
+          "example": "run",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "time_to_live": {
+          "description": "seconds until dyno expires, after which it will soon be killed, max 86400 seconds (24 hours)",
+          "example": 1800,
+          "readOnly": false,
+          "type": [
+            "integer"
+          ]
+        },
+        "updated_at": {
+          "description": "when process last changed state",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new dyno.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "attach": {
+                "$ref": "#/definitions/dyno/definitions/attach"
+              },
+              "command": {
+                "$ref": "#/definitions/dyno/definitions/command"
+              },
+              "env": {
+                "$ref": "#/definitions/dyno/definitions/env"
+              },
+              "force_no_tty": {
+                "$ref": "#/definitions/dyno/definitions/force_no_tty"
+              },
+              "size": {
+                "$ref": "#/definitions/dyno/definitions/size"
+              },
+              "type": {
+                "$ref": "#/definitions/dyno/definitions/type"
+              },
+              "time_to_live": {
+                "$ref": "#/definitions/dyno/definitions/time_to_live"
+              }
+            },
+            "required": [
+              "command"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/dyno"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Restart dyno.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos/{(%23%2Fdefinitions%2Fdyno%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "empty",
+          "targetSchema": {
+            "additionalProperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Restart"
+        },
+        {
+          "description": "Restart dynos of a given formation type.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/formations/{(%23%2Fdefinitions%2Fdyno%2Fdefinitions%2Fformation_type)}",
+          "method": "DELETE",
+          "rel": "empty",
+          "targetSchema": {
+            "additionalProperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Restart formation"
+        },
+        {
+          "description": "Restart all dynos.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos",
+          "method": "DELETE",
+          "rel": "empty",
+          "targetSchema": {
+            "additionalProperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Restart all"
+        },
+        {
+          "description": "Stop dyno.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos/{(%23%2Fdefinitions%2Fdyno%2Fdefinitions%2Fidentity)}/actions/stop",
+          "method": "POST",
+          "rel": "empty",
+          "targetSchema": {
+            "additionalProperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Stop"
+        },
+        {
+          "description": "Stop dynos of a given formation type.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/formations/{(%23%2Fdefinitions%2Fdyno%2Fdefinitions%2Fformation_type)}/actions/stop",
+          "method": "POST",
+          "rel": "empty",
+          "targetSchema": {
+            "additionalProperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Stop formation"
+        },
+        {
+          "description": "Info for existing dyno.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos/{(%23%2Fdefinitions%2Fdyno%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/dyno"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing dynos.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/dyno"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "attach_url": {
+          "$ref": "#/definitions/dyno/definitions/attach_url"
+        },
+        "command": {
+          "$ref": "#/definitions/dyno/definitions/command"
+        },
+        "created_at": {
+          "$ref": "#/definitions/dyno/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/dyno/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/dyno/definitions/name"
+        },
+        "release": {
+          "description": "app release of the dyno",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/release/definitions/id"
+            },
+            "version": {
+              "$ref": "#/definitions/release/definitions/version"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "app": {
+          "description": "app formation belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "size": {
+          "$ref": "#/definitions/dyno/definitions/size"
+        },
+        "state": {
+          "$ref": "#/definitions/dyno/definitions/state"
+        },
+        "type": {
+          "$ref": "#/definitions/dyno/definitions/type"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/dyno/definitions/updated_at"
+        }
+      }
+    },
+    "enterprise-account-daily-usage": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "Usage for an enterprise account at a daily resolution.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Enterprise Account Daily Usage",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "addons": {
+          "description": "total add-on credits used",
+          "example": 250.0,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "data": {
+          "description": "total add-on credits used for first party add-ons",
+          "example": 34.89,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "date": {
+          "description": "date of the usage",
+          "example": "2019-01-01",
+          "format": "date",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "dynos": {
+          "description": "dynos used",
+          "example": 1.548,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "id": {
+          "description": "enterprise account identifier",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "name of the enterprise account",
+          "example": "example-co",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "partner": {
+          "description": "total add-on credits used for third party add-ons",
+          "example": 12.34,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "space": {
+          "description": "space credits used",
+          "example": 1.548,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "start_date": {
+          "description": "range start date",
+          "example": "2019-01-25",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "end_date": {
+          "description": "range end date",
+          "example": "2019-02-25",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieves usage for an enterprise account for a range of days. Start and end dates can be specified as query parameters using the date format YYYY-MM-DD. The enterprise account identifier can be found from the [enterprise account list](https://devcenter.heroku.com/articles/platform-api-reference#enterprise-account-list).\n",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fid)}/usage/daily",
+          "method": "GET",
+          "rel": "instances",
+          "title": "Info",
+          "schema": {
+            "properties": {
+              "start": {
+                "$ref": "#/definitions/enterprise-account-daily-usage/definitions/start_date"
+              },
+              "end": {
+                "$ref": "#/definitions/enterprise-account-daily-usage/definitions/end_date"
+              }
+            },
+            "required": [
+              "start"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/enterprise-account-daily-usage"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "addons": {
+          "$ref": "#/definitions/enterprise-account-daily-usage/definitions/addons"
+        },
+        "teams": {
+          "description": "usage by team",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "addons": {
+                "$ref": "#/definitions/team-daily-usage/definitions/addons"
+              },
+              "apps": {
+                "description": "app usage in the team",
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/team-daily-usage/definitions/app_usage_daily"
+                }
+              },
+              "data": {
+                "$ref": "#/definitions/team-daily-usage/definitions/data"
+              },
+              "dynos": {
+                "$ref": "#/definitions/team-daily-usage/definitions/dynos"
+              },
+              "id": {
+                "$ref": "#/definitions/team-daily-usage/definitions/id"
+              },
+              "name": {
+                "$ref": "#/definitions/team-daily-usage/definitions/name"
+              },
+              "partner": {
+                "$ref": "#/definitions/team-daily-usage/definitions/partner"
+              },
+              "space": {
+                "$ref": "#/definitions/team-daily-usage/definitions/space"
+              }
+            }
+          }
+        },
+        "data": {
+          "$ref": "#/definitions/enterprise-account-daily-usage/definitions/data"
+        },
+        "date": {
+          "$ref": "#/definitions/enterprise-account-daily-usage/definitions/date"
+        },
+        "dynos": {
+          "$ref": "#/definitions/enterprise-account-daily-usage/definitions/dynos"
+        },
+        "id": {
+          "$ref": "#/definitions/enterprise-account-daily-usage/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/enterprise-account-daily-usage/definitions/name"
+        },
+        "partner": {
+          "$ref": "#/definitions/enterprise-account-daily-usage/definitions/partner"
+        },
+        "space": {
+          "$ref": "#/definitions/enterprise-account-daily-usage/definitions/space"
+        }
+      }
+    },
+    "enterprise-account-member": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "Enterprise account members are users with access to an enterprise account.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Enterprise Account Member",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of the member",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/enterprise-account-member/definitions/id"
+            }
+          ]
+        },
+        "permission": {
+          "description": "permission in the enterprise account",
+          "enum": [
+            "view",
+            "create",
+            "manage",
+            "billing"
+          ],
+          "example": "view",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "permissions": {
+          "description": "permissions for enterprise account",
+          "example": [
+            "view"
+          ],
+          "readOnly": true,
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/enterprise-account-member/definitions/permission"
+          }
+        },
+        "expanded_permissions": {
+          "description": "enterprise account permissions",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "description": {
+                "type": [
+                  "string"
+                ],
+                "example": "View enterprise account members and teams."
+              },
+              "name": {
+                "$ref": "#/definitions/enterprise-account-member/definitions/permission",
+                "example": "view"
+              }
+            }
+          }
+        },
+        "user_identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          ]
+        },
+        "two_factor_authentication": {
+          "description": "whether the Enterprise Account member has two factor authentication enabled",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "identity_provider": {
+          "description": "Identity Provider information the member is federated with",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/identity-provider/definitions/id"
+            },
+            "name": {
+              "description": "name of the identity provider",
+              "example": "acme",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "redacted": {
+              "description": "whether the identity_provider information is redacted or not",
+              "example": false,
+              "readOnly": true,
+              "type": [
+                "boolean"
+              ]
+            },
+            "owner": {
+              "$ref": "#/definitions/identity-provider/definitions/owner"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List members in an enterprise account.",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}/members",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/enterprise-account-member"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Create a member in an enterprise account.",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}/members",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "user": {
+                "$ref": "#/definitions/enterprise-account-member/definitions/user_identity"
+              },
+              "permissions": {
+                "$ref": "#/definitions/enterprise-account-member/definitions/permissions"
+              },
+              "federated": {
+                "description": "whether membership is being created as part of SSO JIT",
+                "example": false,
+                "type": [
+                  "boolean"
+                ]
+              }
+            },
+            "required": [
+              "user",
+              "permissions"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/enterprise-account-member"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Update a member in an enterprise account.",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Fenterprise-account-member%2Fdefinitions%2Fuser_identity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "permissions": {
+                "$ref": "#/definitions/enterprise-account-member/definitions/permissions"
+              }
+            },
+            "required": [
+              "permissions"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/enterprise-account-member"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "delete a member in an enterprise account.",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Fenterprise-account-member%2Fdefinitions%2Fuser_identity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/enterprise-account-member"
+          },
+          "title": "Delete"
+        }
+      ],
+      "properties": {
+        "enterprise_account": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/enterprise-account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/enterprise-account/definitions/name"
+            }
+          }
+        },
+        "id": {
+          "$ref": "#/definitions/enterprise-account-member/definitions/id"
+        },
+        "permissions": {
+          "$ref": "#/definitions/enterprise-account-member/definitions/expanded_permissions"
+        },
+        "user": {
+          "description": "user information for the membership",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "two_factor_authentication": {
+          "$ref": "#/definitions/enterprise-account-member/definitions/two_factor_authentication"
+        },
+        "identity_provider": {
+          "$ref": "#/definitions/enterprise-account-member/definitions/identity_provider"
+        }
+      }
+    },
+    "enterprise-account-monthly-usage": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "Usage for an enterprise account at a monthly resolution.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Enterprise Account Monthly Usage",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "addons": {
+          "description": "total add-on credits used",
+          "example": 250.0,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "connect": {
+          "description": "max connect rows synced",
+          "example": 15000,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "data": {
+          "description": "total add-on credits used for first party add-ons",
+          "example": 34.89,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "dynos": {
+          "description": "dynos used",
+          "example": 1.548,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "month": {
+          "description": "year and month of the usage",
+          "example": "2019-01",
+          "pattern": "^[0-9]{4}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "enterprise account identifier",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "name of the enterprise account",
+          "example": "example-co",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "partner": {
+          "description": "total add-on credits used for third party add-ons",
+          "example": 12.34,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "space": {
+          "description": "space credits used",
+          "example": 1.548,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "start_date": {
+          "description": "range start date",
+          "example": "2019-01",
+          "pattern": "^[0-9]{4}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "end_date": {
+          "description": "range end date",
+          "example": "2019-02",
+          "pattern": "^[0-9]{4}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieves usage for an enterprise account for a range of months. Start and end dates can be specified as query parameters using the date format YYYY-MM. If no end date is specified, one month of usage is returned. The enterprise account identifier can be found from the [enterprise account list](https://devcenter.heroku.com/articles/platform-api-reference#enterprise-account-list).\n",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fid)}/usage/monthly",
+          "method": "GET",
+          "rel": "instances",
+          "title": "Info",
+          "schema": {
+            "properties": {
+              "start": {
+                "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/start_date"
+              },
+              "end": {
+                "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/end_date"
+              }
+            },
+            "required": [
+              "start"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/enterprise-account-monthly-usage"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "addons": {
+          "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/addons"
+        },
+        "teams": {
+          "description": "usage by team",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "addons": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/addons"
+              },
+              "apps": {
+                "description": "app usage in the team",
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/team-monthly-usage/definitions/app_usage_monthly"
+                }
+              },
+              "connect": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/connect"
+              },
+              "data": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/data"
+              },
+              "dynos": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/dynos"
+              },
+              "id": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/id"
+              },
+              "name": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/name"
+              },
+              "partner": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/partner"
+              },
+              "space": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/space"
+              }
+            }
+          }
+        },
+        "connect": {
+          "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/connect"
+        },
+        "data": {
+          "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/data"
+        },
+        "dynos": {
+          "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/dynos"
+        },
+        "id": {
+          "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/id"
+        },
+        "month": {
+          "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/month"
+        },
+        "name": {
+          "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/name"
+        },
+        "partner": {
+          "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/partner"
+        },
+        "space": {
+          "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/space"
+        }
+      }
+    },
+    "enterprise-account": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "Enterprise accounts allow companies to manage their development teams and billing.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Enterprise Account",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when the enterprise account was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of the enterprise account",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/enterprise-account/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/enterprise-account/definitions/name"
+            }
+          ]
+        },
+        "identity_provider": {
+          "description": "Identity Provider associated with the Enterprise Account",
+          "strictProperties": true,
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/identity-provider/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/identity-provider/definitions/name"
+            },
+            "owner": {
+              "$ref": "#/definitions/identity-provider/definitions/owner"
+            }
+          }
+        },
+        "name": {
+          "description": "unique name of the enterprise account",
+          "example": "example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the enterprise account was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "permissions": {
+          "description": "the current user's permissions for this enterprise account",
+          "readOnly": true,
+          "type": [
+            "array"
+          ],
+          "items": {
+            "example": "view",
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "trial": {
+          "description": "whether the enterprise account is a trial or not",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List enterprise accounts in which you are a member.",
+          "href": "/enterprise-accounts",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/enterprise-account"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Information about an enterprise account.",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/enterprise-account"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update enterprise account properties",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/enterprise-account/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/enterprise-account"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/enterprise-account/definitions/id"
+        },
+        "created_at": {
+          "$ref": "#/definitions/enterprise-account/definitions/created_at"
+        },
+        "name": {
+          "$ref": "#/definitions/enterprise-account/definitions/name"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/enterprise-account/definitions/updated_at"
+        },
+        "permissions": {
+          "$ref": "#/definitions/enterprise-account/definitions/permissions"
+        },
+        "trial": {
+          "$ref": "#/definitions/enterprise-account/definitions/trial"
+        },
+        "identity_provider": {
+          "$ref": "#/definitions/enterprise-account/definitions/identity_provider"
+        }
+      }
+    },
+    "filter-apps": {
+      "description": "Filters are special endpoints to allow for API consumers to specify a subset of resources to consume in order to reduce the number of requests that are performed.  Each filter endpoint endpoint is responsible for determining its supported request format.  The endpoints are over POST in order to handle large request bodies without hitting request uri query length limitations, but the requests themselves are idempotent and will not have side effects.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "title": "Heroku Platform API - Filters",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "filter": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "in": {
+              "$ref": "#/definitions/filter-apps/definitions/in"
+            }
+          }
+        },
+        "in": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/filter-apps/definitions/id"
+            }
+          }
+        },
+        "id": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/app/definitions/id"
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Request an apps list filtered by app id.",
+          "title": "Apps",
+          "href": "/filters/apps",
+          "method": "POST",
+          "ranges": [
+            "id",
+            "name",
+            "updated_at"
+          ],
+          "rel": "instances",
+          "schema": {
+            "$ref": "#/definitions/filter-apps/definitions/filter"
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        }
+      ]
+    },
+    "formation": {
+      "description": "The formation of processes that should be maintained for an app. Update the formation to scale processes or change dyno sizes. Available process type names and commands are defined by the `process_types` attribute for the [slug](#slug) currently released on an app.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Formation",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "command": {
+          "description": "command to use to launch this process",
+          "example": "bundle exec rails server -p $PORT",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when process type was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "dyno_size": {
+          "description": "dyno size",
+          "example": {
+            "id": "01234567-89ab-cdef-0123-456789abcdef"
+          },
+          "oneOf": [
+            {
+              "required": [
+                "id"
+              ]
+            },
+            {
+              "required": [
+                "name"
+              ]
+            }
+          ],
+          "properties": {
+            "id": {
+              "description": "unique identifier of the dyno size",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "name": {
+              "description": "name of the dyno size",
+              "example": "Standard-1X",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "readOnly": false,
+          "required": [
+            "id"
+          ],
+          "type": [
+            "object"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this process type",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/formation/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/formation/definitions/type"
+            }
+          ]
+        },
+        "quantity": {
+          "description": "number of processes to maintain",
+          "example": 1,
+          "readOnly": false,
+          "type": [
+            "integer"
+          ]
+        },
+        "size": {
+          "deprecated": true,
+          "description": "deprecated, refer to 'dyno_size' instead",
+          "example": "standard-1X",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "type of process to maintain",
+          "example": "web",
+          "readOnly": true,
+          "pattern": "^[-\\w]{1,128}$",
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when dyno type was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "update": {
+          "additionalProperties": false,
+          "description": "Properties to update a process type",
+          "properties": {
+            "dyno_size": {
+              "$ref": "#/definitions/formation/definitions/dyno_size"
+            },
+            "quantity": {
+              "$ref": "#/definitions/formation/definitions/quantity"
+            },
+            "type": {
+              "$ref": "#/definitions/formation/definitions/type"
+            }
+          },
+          "readOnly": false,
+          "required": [
+            "type"
+          ],
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for a process type",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/formation/{(%23%2Fdefinitions%2Fformation%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/formation"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List process type formation",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/formation",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/formation"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Batch update process types",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/formation",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "updates": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/formation/definitions/update"
+                },
+                "description": "Array with formation updates. Each element must have \"type\", the id or name of the process type to be updated, and can optionally update its \"quantity\" or \"dyno_size\"."
+              }
+            },
+            "required": [
+              "updates"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/formation"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Batch Update"
+        },
+        {
+          "description": "Update process type",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/formation/{(%23%2Fdefinitions%2Fformation%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "dyno_size": {
+                "$ref": "#/definitions/formation/definitions/dyno_size"
+              },
+              "quantity": {
+                "$ref": "#/definitions/formation/definitions/quantity"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/formation"
+          },
+          "title": "Update",
+          "type": [
+            "object"
+          ]
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "app formation belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "command": {
+          "$ref": "#/definitions/formation/definitions/command"
+        },
+        "created_at": {
+          "$ref": "#/definitions/formation/definitions/created_at"
+        },
+        "dyno_size": {
+          "description": "dyno size",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/dyno-size/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/dyno-size/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/formation/definitions/id"
+        },
+        "quantity": {
+          "$ref": "#/definitions/formation/definitions/quantity"
+        },
+        "size": {
+          "$ref": "#/definitions/formation/definitions/size"
+        },
+        "type": {
+          "$ref": "#/definitions/formation/definitions/type"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/formation/definitions/updated_at"
+        }
+      }
+    },
+    "generation": {
+      "description": "A generation represents a version of the Heroku platform that includes the app execution environment, routing, telemetry, and build systems.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Generation",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when generation was created",
+          "example": "2024-12-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of generation",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/generation/definitions/name"
+            },
+            {
+              "$ref": "#/definitions/generation/definitions/id"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of generation",
+          "example": "fir",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when generation was updated",
+          "example": "2024-12-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for generation.",
+          "href": "/generations/{(%23%2Fdefinitions%2Fstack%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/generation"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List available generations.",
+          "href": "/generations",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/generation"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List available generations for a team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/available-generations",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/generation"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by Team"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/generation/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/generation/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/generation/definitions/name"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/generation/definitions/updated_at"
+        }
+      }
+    },
+    "identity-provider": {
+      "description": "Identity Providers represent the SAML configuration of teams or an Enterprise account",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Identity Provider",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "certificate": {
+          "description": "raw contents of the public certificate (eg: .crt or .pem file)",
+          "example": "-----BEGIN CERTIFICATE----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when provider record was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "entity_id": {
+          "description": "URL identifier provided by the identity provider",
+          "example": "https://customer-domain.idp.com",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this identity provider",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "user-friendly unique identifier for this identity provider",
+          "example": "acme-sso",
+          "type": [
+            "string"
+          ]
+        },
+        "slo_target_url": {
+          "description": "single log out URL for this identity provider",
+          "example": "https://example.com/idp/logout",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "sso_target_url": {
+          "description": "single sign on URL for this identity provider",
+          "example": "https://example.com/idp/login",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the identity provider record was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "owner": {
+          "description": "entity that owns this identity provider",
+          "properties": {
+            "id": {
+              "description": "unique identifier of the owner",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "name": {
+              "description": "name of the owner",
+              "example": "acme",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "type": {
+              "description": "type of the owner",
+              "enum": [
+                "team",
+                "enterprise-account"
+              ],
+              "example": "team",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "readOnly": false,
+          "required": [
+            "id",
+            "type"
+          ],
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get a list of a team's Identity Providers",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fname)}/identity-providers",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/identity-provider"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
+        },
+        {
+          "description": "Create an Identity Provider for a team",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fname)}/identity-providers",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "required": [
+              "certificate",
+              "sso_target_url",
+              "entity_id"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Create By Team"
+        },
+        {
+          "description": "Update a team's Identity Provider",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fname)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Update By Team"
+        },
+        {
+          "description": "Delete a team's Identity Provider",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fname)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Delete By Team"
+        }
+      ],
+      "properties": {
+        "certificate": {
+          "$ref": "#/definitions/identity-provider/definitions/certificate"
+        },
+        "created_at": {
+          "$ref": "#/definitions/identity-provider/definitions/created_at"
+        },
+        "entity_id": {
+          "$ref": "#/definitions/identity-provider/definitions/entity_id"
+        },
+        "id": {
+          "$ref": "#/definitions/identity-provider/definitions/id"
+        },
+        "slo_target_url": {
+          "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+        },
+        "sso_target_url": {
+          "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+        },
+        "organization": {
+          "description": "team associated with this identity provider",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "updated_at": {
+          "$ref": "#/definitions/identity-provider/definitions/updated_at"
+        },
+        "owner": {
+          "$ref": "#/definitions/identity-provider/definitions/owner"
+        }
+      }
+    },
+    "inbound-ruleset": {
+      "description": "An inbound-ruleset is a collection of rules that specify what hosts can or cannot connect to an application.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Inbound Ruleset",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "action": {
+          "description": "states whether the connection is allowed or denied",
+          "example": "allow",
+          "readOnly": false,
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "allow",
+            "deny"
+          ]
+        },
+        "source": {
+          "description": "is the request’s source in CIDR notation",
+          "example": "1.1.1.1/1",
+          "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when inbound-ruleset was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of an inbound-ruleset",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/inbound-ruleset/definitions/id"
+            }
+          ]
+        },
+        "rule": {
+          "description": "the combination of an IP address in CIDR notation and whether to allow or deny it's traffic.",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "action": {
+              "$ref": "#/definitions/inbound-ruleset/definitions/action"
+            },
+            "source": {
+              "$ref": "#/definitions/inbound-ruleset/definitions/source"
+            }
+          },
+          "required": [
+            "source",
+            "action"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Current inbound ruleset for a space",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/inbound-ruleset",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/inbound-ruleset"
+          },
+          "title": "Current"
+        },
+        {
+          "description": "Info on an existing Inbound Ruleset",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/inbound-rulesets/{(%23%2Fdefinitions%2Finbound-ruleset%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/inbound-ruleset"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List all inbound rulesets for a space",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/inbound-rulesets",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/inbound-ruleset"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Create a new inbound ruleset",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/inbound-ruleset",
+          "method": "PUT",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/inbound-ruleset"
+          },
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "rules": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/inbound-ruleset/definitions/rule"
+                }
+              }
+            }
+          },
+          "title": "Create"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/inbound-ruleset/definitions/id"
+        },
+        "space": {
+          "description": "identity of space",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/space/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/space/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/inbound-ruleset/definitions/created_at"
+        },
+        "rules": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/inbound-ruleset/definitions/rule"
+          }
+        },
+        "created_by": {
+          "$ref": "#/definitions/account/definitions/email"
+        }
+      }
+    },
+    "invoice-address": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "An invoice address represents the address that should be listed on an invoice.",
+      "title": "Heroku Vault API - Invoice Address",
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "address_1": {
+          "type": [
+            "string"
+          ],
+          "description": "invoice street address line 1",
+          "example": "40 Hickory Blvd."
+        },
+        "address_2": {
+          "type": [
+            "string"
+          ],
+          "description": "invoice street address line 2",
+          "example": "Suite 300"
+        },
+        "city": {
+          "type": [
+            "string"
+          ],
+          "description": "invoice city",
+          "example": "Seattle"
+        },
+        "country": {
+          "type": [
+            "string"
+          ],
+          "description": "country",
+          "example": "US"
+        },
+        "heroku_id": {
+          "type": [
+            "string"
+          ],
+          "description": "heroku_id identifier reference",
+          "example": "user930223902@heroku.com",
+          "readOnly": true
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/invoice-address/definitions/heroku_id"
+            }
+          ]
+        },
+        "other": {
+          "type": [
+            "string"
+          ],
+          "description": "metadata / additional information to go on invoice",
+          "example": "Company ABC Inc. VAT 903820"
+        },
+        "postal_code": {
+          "type": [
+            "string"
+          ],
+          "description": "invoice zip code",
+          "example": "98101"
+        },
+        "state": {
+          "type": [
+            "string"
+          ],
+          "description": "invoice state",
+          "example": "WA"
+        },
+        "use_invoice_address": {
+          "type": [
+            "boolean"
+          ],
+          "description": "flag to use the invoice address for an account or not",
+          "example": true,
+          "default": false
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieve existing invoice address.",
+          "href": "/account/invoice-address",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/invoice-address"
+          },
+          "title": "info"
+        },
+        {
+          "description": "Update invoice address for an account.",
+          "href": "/account/invoice-address",
+          "method": "PUT",
+          "rel": "self",
+          "title": "update",
+          "schema": {
+            "properties": {
+              "address_1": {
+                "$ref": "#/definitions/invoice-address/definitions/address_1"
+              },
+              "address_2": {
+                "$ref": "#/definitions/invoice-address/definitions/address_2"
+              },
+              "city": {
+                "$ref": "#/definitions/invoice-address/definitions/city"
+              },
+              "country": {
+                "$ref": "#/definitions/invoice-address/definitions/country"
+              },
+              "other": {
+                "$ref": "#/definitions/invoice-address/definitions/other"
+              },
+              "postal_code": {
+                "$ref": "#/definitions/invoice-address/definitions/postal_code"
+              },
+              "state": {
+                "$ref": "#/definitions/invoice-address/definitions/state"
+              },
+              "use_invoice_address": {
+                "$ref": "#/definitions/invoice-address/definitions/use_invoice_address"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/invoice-address"
+          }
+        }
+      ],
+      "properties": {
+        "address_1": {
+          "$ref": "#/definitions/invoice-address/definitions/address_1"
+        },
+        "address_2": {
+          "$ref": "#/definitions/invoice-address/definitions/address_2"
+        },
+        "city": {
+          "$ref": "#/definitions/invoice-address/definitions/city"
+        },
+        "country": {
+          "$ref": "#/definitions/invoice-address/definitions/country"
+        },
+        "heroku_id": {
+          "$ref": "#/definitions/invoice-address/definitions/identity"
+        },
+        "other": {
+          "$ref": "#/definitions/invoice-address/definitions/other"
+        },
+        "postal_code": {
+          "$ref": "#/definitions/invoice-address/definitions/postal_code"
+        },
+        "state": {
+          "$ref": "#/definitions/invoice-address/definitions/state"
+        },
+        "use_invoice_address": {
+          "$ref": "#/definitions/invoice-address/definitions/use_invoice_address"
+        }
+      }
+    },
+    "invoice": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "An invoice is an itemized bill of goods for an account which includes pricing and charges.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Invoice",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "charges_total": {
+          "description": "total charges on this invoice",
+          "example": 100.0,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "created_at": {
+          "description": "when invoice was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "credits_total": {
+          "description": "total credits on this invoice",
+          "example": 100.0,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this invoice",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/invoice/definitions/number"
+            }
+          ]
+        },
+        "number": {
+          "description": "human readable invoice number",
+          "example": 9403943,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "period_end": {
+          "description": "the ending date that the invoice covers",
+          "example": "01/31/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "period_start": {
+          "description": "the starting date that this invoice covers",
+          "example": "01/01/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "payment status for this invoice (pending, successful, failed)",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "total": {
+          "description": "combined total of charges and credits on this invoice",
+          "example": 100.0,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "updated_at": {
+          "description": "when invoice was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing invoice.",
+          "href": "/account/invoices/{(%23%2Fdefinitions%2Finvoice%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/invoice"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing invoices.",
+          "href": "/account/invoices",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/invoice"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "charges_total": {
+          "$ref": "#/definitions/invoice/definitions/charges_total"
+        },
+        "created_at": {
+          "$ref": "#/definitions/invoice/definitions/created_at"
+        },
+        "credits_total": {
+          "$ref": "#/definitions/invoice/definitions/credits_total"
+        },
+        "id": {
+          "$ref": "#/definitions/invoice/definitions/id"
+        },
+        "number": {
+          "$ref": "#/definitions/invoice/definitions/number"
+        },
+        "period_end": {
+          "$ref": "#/definitions/invoice/definitions/period_end"
+        },
+        "period_start": {
+          "$ref": "#/definitions/invoice/definitions/period_start"
+        },
+        "state": {
+          "$ref": "#/definitions/invoice/definitions/state"
+        },
+        "total": {
+          "$ref": "#/definitions/invoice/definitions/total"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/invoice/definitions/updated_at"
+        }
+      }
+    },
+    "key": {
+      "description": "Keys represent public SSH keys associated with an account and are used to authorize accounts as they are performing git operations.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Key",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "comment": {
+          "description": "comment on the key",
+          "example": "username@host",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when key was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "email": {
+          "deprecated": true,
+          "description": "deprecated. Please refer to 'comment' instead",
+          "example": "username@host",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "fingerprint": {
+          "description": "a unique identifying string based on contents",
+          "example": "17:63:a4:ba:24:d3:7f:af:17:c8:94:82:7e:80:56:bf",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this key",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/key/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/key/definitions/fingerprint"
+            }
+          ]
+        },
+        "public_key": {
+          "description": "full public_key as uploaded",
+          "example": "ssh-rsa AAAAB3NzaC1ycVc/../839Uv username@example.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when key was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing key.",
+          "href": "/account/keys/{(%23%2Fdefinitions%2Fkey%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/key"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing keys.",
+          "href": "/account/keys",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/key"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "comment": {
+          "$ref": "#/definitions/key/definitions/comment"
+        },
+        "created_at": {
+          "$ref": "#/definitions/key/definitions/created_at"
+        },
+        "email": {
+          "$ref": "#/definitions/key/definitions/email"
+        },
+        "fingerprint": {
+          "$ref": "#/definitions/key/definitions/fingerprint"
+        },
+        "id": {
+          "$ref": "#/definitions/key/definitions/id"
+        },
+        "public_key": {
+          "$ref": "#/definitions/key/definitions/public_key"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/key/definitions/updated_at"
+        }
+      }
+    },
+    "log-drain": {
+      "description": "[Log drains](https://devcenter.heroku.com/articles/log-drains) provide a way to forward your Heroku logs to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets from Heroku, whereupon its URL can be added to an app using this API. Some add-ons will add a log drain when they are provisioned to an app. These drains can only be removed by removing the add-on.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Log Drain",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "addon": {
+          "description": "add-on that created the drain",
+          "example": {
+            "id": "01234567-89ab-cdef-0123-456789abcdef",
+            "name": "singing-swiftly-1242",
+            "app": {
+              "id": "01234567-89ab-cdef-0123-456789abcdef",
+              "name": "example"
+            }
+          },
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/add-on/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/add-on/definitions/name"
+            },
+            "app": {
+              "description": "billing application associated with this add-on",
+              "type": [
+                "object"
+              ],
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/app/definitions/id"
+                },
+                "name": {
+                  "$ref": "#/definitions/app/definitions/name"
+                }
+              },
+              "strictProperties": true
+            }
+          },
+          "readOnly": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "app": {
+          "description": "application that is attached to this drain",
+          "example": {
+            "id": "01234567-89ab-cdef-0123-456789abcdef",
+            "name": "example"
+          },
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "readOnly": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "created_at": {
+          "description": "when log drain was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this log drain",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "query_identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/log-drain/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/log-drain/definitions/url"
+            },
+            {
+              "$ref": "#/definitions/log-drain/definitions/token"
+            }
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/log-drain/definitions/url"
+            }
+          ]
+        },
+        "token": {
+          "description": "token associated with the log drain",
+          "example": "d.01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when log drain was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "url": {
+          "description": "url associated with the log drain",
+          "example": "https://example.com/drain",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new log drain.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/log-drains",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "url": {
+                "$ref": "#/definitions/log-drain/definitions/url"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/log-drain"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Update an add-on owned log drain.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/log-drains/{(%23%2Fdefinitions%2Flog-drain%2Fdefinitions%2Fquery_identity)}",
+          "method": "PUT",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "url": {
+                "$ref": "#/definitions/log-drain/definitions/url"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/log-drain"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Delete an existing log drain. Log drains added by add-ons can only be removed by removing the add-on.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/log-drains/{(%23%2Fdefinitions%2Flog-drain%2Fdefinitions%2Fquery_identity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/log-drain"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for existing log drain.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/log-drains/{(%23%2Fdefinitions%2Flog-drain%2Fdefinitions%2Fquery_identity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/log-drain"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing log drains for an add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/log-drains",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/log-drain"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Add-on"
+        },
+        {
+          "description": "List existing log drains.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/log-drains",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/log-drain"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "addon": {
+          "$ref": "#/definitions/log-drain/definitions/addon"
+        },
+        "app": {
+          "$ref": "#/definitions/log-drain/definitions/app"
+        },
+        "created_at": {
+          "$ref": "#/definitions/log-drain/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/log-drain/definitions/id"
+        },
+        "token": {
+          "$ref": "#/definitions/log-drain/definitions/token"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/log-drain/definitions/updated_at"
+        },
+        "url": {
+          "$ref": "#/definitions/log-drain/definitions/url"
+        }
+      }
+    },
+    "log-session": {
+      "description": "A log session is a reference to the http based log stream for an app.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Log Session",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when log connection was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "dyno_name": {
+          "description": "dyno name to limit results to",
+          "example": "'web.1' (Cedar-generation) or 'web-1234abcde-123ab' (Fir-generation)",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "process type to limit results to",
+          "example": "web",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this log session",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/log-session/definitions/id"
+            }
+          ]
+        },
+        "lines": {
+          "description": "number of log lines to stream at once",
+          "example": 10,
+          "readOnly": false,
+          "type": [
+            "integer"
+          ]
+        },
+        "logplex_url": {
+          "description": "URL for log streaming session",
+          "example": "https://logplex.heroku.com/sessions/01234567-89ab-cdef-0123-456789abcdef?srv=1325419200",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "source": {
+          "description": "log source to limit results to",
+          "example": "app",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "tail": {
+          "description": "whether to stream ongoing logs",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "updated_at": {
+          "description": "when log session was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new log session.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/log-sessions",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "dyno_name": {
+                "$ref": "#/definitions/log-session/definitions/dyno_name"
+              },
+              "type": {
+                "$ref": "#/definitions/log-session/definitions/type"
+              },
+              "lines": {
+                "$ref": "#/definitions/log-session/definitions/lines"
+              },
+              "source": {
+                "$ref": "#/definitions/log-session/definitions/source"
+              },
+              "tail": {
+                "$ref": "#/definitions/log-session/definitions/tail"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/log-session"
+          },
+          "title": "Create"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/log-session/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/log-session/definitions/id"
+        },
+        "logplex_url": {
+          "$ref": "#/definitions/log-session/definitions/logplex_url"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/log-session/definitions/updated_at"
+        }
+      }
+    },
+    "oauth-authorization": {
+      "description": "OAuth authorizations represent clients that a Heroku user has authorized to automate, customize or extend their usage of the platform. For more information please refer to the [Heroku OAuth documentation](https://devcenter.heroku.com/articles/oauth)",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - OAuth Authorization",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when OAuth authorization was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "human-friendly description of this OAuth authorization",
+          "example": "sample authorization",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of OAuth authorization",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/oauth-authorization/definitions/id"
+            }
+          ]
+        },
+        "scope": {
+          "description": "The scope of access OAuth authorization allows",
+          "example": [
+            "global"
+          ],
+          "readOnly": true,
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "updated_at": {
+          "description": "when OAuth authorization was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new OAuth authorization.",
+          "href": "/oauth/authorizations",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "client": {
+                "$ref": "#/definitions/oauth-client/definitions/identity"
+              },
+              "description": {
+                "$ref": "#/definitions/oauth-authorization/definitions/description"
+              },
+              "expires_in": {
+                "$ref": "#/definitions/oauth-token/definitions/expires_in"
+              },
+              "scope": {
+                "$ref": "#/definitions/oauth-authorization/definitions/scope"
+              }
+            },
+            "required": [
+              "scope"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-authorization"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete OAuth authorization.",
+          "href": "/oauth/authorizations/{(%23%2Fdefinitions%2Foauth-authorization%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-authorization"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for an OAuth authorization.",
+          "href": "/oauth/authorizations/{(%23%2Fdefinitions%2Foauth-authorization%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-authorization"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update an existing OAuth authorization.",
+          "href": "/oauth/authorizations/{(%23%2Fdefinitions%2Foauth-authorization%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-authorization"
+          },
+          "schema": {
+            "properties": {
+              "description": {
+                "$ref": "#/definitions/oauth-authorization/definitions/description"
+              },
+              "client": {
+                "type": [
+                  "object"
+                ],
+                "description": "identifier of the client that obtained this authorization",
+                "properties": {
+                  "id": {
+                    "$ref": "#/definitions/oauth-client/definitions/id"
+                  },
+                  "secret": {
+                    "$ref": "#/definitions/oauth-client/definitions/secret"
+                  }
+                }
+              }
+            },
+            "required": [
+              "client"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Update"
+        },
+        {
+          "description": "List OAuth authorizations.",
+          "href": "/oauth/authorizations",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/oauth-authorization"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Regenerate OAuth tokens. This endpoint is only available to direct authorizations or privileged OAuth clients.",
+          "href": "/oauth/authorizations/{(%23%2Fdefinitions%2Foauth-authorization%2Fdefinitions%2Fidentity)}/actions/regenerate-tokens",
+          "method": "POST",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-authorization"
+          },
+          "title": "Regenerate"
+        }
+      ],
+      "properties": {
+        "access_token": {
+          "description": "access token for this authorization",
+          "properties": {
+            "expires_in": {
+              "$ref": "#/definitions/oauth-token/definitions/expires_in"
+            },
+            "id": {
+              "$ref": "#/definitions/oauth-token/definitions/id"
+            },
+            "token": {
+              "$ref": "#/definitions/oauth-token/definitions/token"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "client": {
+          "description": "identifier of the client that obtained this authorization, if any",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/oauth-client/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/oauth-client/definitions/name"
+            },
+            "redirect_uri": {
+              "$ref": "#/definitions/oauth-client/definitions/redirect_uri"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/oauth-authorization/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/oauth-authorization/definitions/description"
+        },
+        "grant": {
+          "description": "this authorization's grant",
+          "properties": {
+            "code": {
+              "$ref": "#/definitions/oauth-grant/definitions/code"
+            },
+            "expires_in": {
+              "$ref": "#/definitions/oauth-grant/definitions/expires_in"
+            },
+            "id": {
+              "$ref": "#/definitions/oauth-grant/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/oauth-authorization/definitions/id"
+        },
+        "refresh_token": {
+          "description": "refresh token for this authorization",
+          "properties": {
+            "expires_in": {
+              "$ref": "#/definitions/oauth-token/definitions/expires_in"
+            },
+            "id": {
+              "$ref": "#/definitions/oauth-token/definitions/id"
+            },
+            "token": {
+              "$ref": "#/definitions/oauth-token/definitions/token"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "scope": {
+          "$ref": "#/definitions/oauth-authorization/definitions/scope"
+        },
+        "session": {
+          "description": "this authorization's session",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/oauth-token/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "updated_at": {
+          "$ref": "#/definitions/oauth-authorization/definitions/updated_at"
+        },
+        "user": {
+          "description": "authenticated user associated with this authorization",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "full_name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "oauth-client": {
+      "description": "OAuth clients are applications that Heroku users can authorize to automate, customize or extend their usage of the platform. For more information please refer to the [Heroku OAuth documentation](https://devcenter.heroku.com/articles/oauth).",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - OAuth Client",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when OAuth client was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this OAuth client",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/oauth-client/definitions/id"
+            }
+          ]
+        },
+        "ignores_delinquent": {
+          "description": "whether the client is still operable given a delinquent account",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "OAuth client name",
+          "example": "example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "redirect_uri": {
+          "description": "endpoint for redirection after authorization with OAuth client",
+          "example": "https://example.com/auth/heroku/callback",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "secret": {
+          "description": "secret used to obtain OAuth authorizations under this client",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when OAuth client was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new OAuth client.",
+          "href": "/oauth/clients",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/oauth-client/definitions/name"
+              },
+              "redirect_uri": {
+                "$ref": "#/definitions/oauth-client/definitions/redirect_uri"
+              }
+            },
+            "required": [
+              "name",
+              "redirect_uri"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-client"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete OAuth client.",
+          "href": "/oauth/clients/{(%23%2Fdefinitions%2Foauth-client%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-client"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for an OAuth client. The output for unauthenticated requests excludes the `secret` parameter.",
+          "href": "/oauth/clients/{(%23%2Fdefinitions%2Foauth-client%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "List OAuth clients",
+          "href": "/oauth/clients",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/oauth-client"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update OAuth client",
+          "href": "/oauth/clients/{(%23%2Fdefinitions%2Foauth-client%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/oauth-client/definitions/name"
+              },
+              "redirect_uri": {
+                "$ref": "#/definitions/oauth-client/definitions/redirect_uri"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-client"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Rotate credentials for an OAuth client",
+          "href": "/oauth/clients/{(%23%2Fdefinitions%2Foauth-client%2Fdefinitions%2Fidentity)}/actions/rotate-credentials",
+          "method": "POST",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-client"
+          },
+          "title": "Rotate Credentials"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/oauth-client/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/oauth-client/definitions/id"
+        },
+        "ignores_delinquent": {
+          "$ref": "#/definitions/oauth-client/definitions/ignores_delinquent"
+        },
+        "name": {
+          "$ref": "#/definitions/oauth-client/definitions/name"
+        },
+        "redirect_uri": {
+          "$ref": "#/definitions/oauth-client/definitions/redirect_uri"
+        },
+        "secret": {
+          "$ref": "#/definitions/oauth-client/definitions/secret"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/oauth-client/definitions/updated_at"
+        }
+      }
+    },
+    "oauth-grant": {
+      "description": "OAuth grants are used to obtain authorizations on behalf of a user. For more information please refer to the [Heroku OAuth documentation](https://devcenter.heroku.com/articles/oauth)",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - OAuth Grant",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "code": {
+          "description": "grant code received from OAuth web application authorization",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "expires_in": {
+          "description": "seconds until OAuth grant expires",
+          "example": 2592000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of OAuth grant",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/oauth-grant/definitions/id"
+            }
+          ]
+        },
+        "type": {
+          "description": "type of grant requested, one of `authorization_code` or `refresh_token`",
+          "example": "authorization_code",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [],
+      "properties": {}
+    },
+    "oauth-token": {
+      "description": "OAuth tokens provide access for authorized clients to act on behalf of a Heroku user to automate, customize or extend their usage of the platform. For more information please refer to the [Heroku OAuth documentation](https://devcenter.heroku.com/articles/oauth)",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - OAuth Token",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when OAuth token was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "expires_in": {
+          "description": "seconds until OAuth token expires; may be `null` for tokens with indefinite lifetime",
+          "example": 2592000,
+          "readOnly": true,
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of OAuth token",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/oauth-token/definitions/id"
+            }
+          ]
+        },
+        "token": {
+          "description": "contents of the token to be used for authorization",
+          "example": "HRKU-01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when OAuth token was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new OAuth token.",
+          "href": "/oauth/tokens",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "client": {
+                "type": [
+                  "object"
+                ],
+                "properties": {
+                  "secret": {
+                    "$ref": "#/definitions/oauth-client/definitions/secret"
+                  }
+                }
+              },
+              "grant": {
+                "type": [
+                  "object"
+                ],
+                "properties": {
+                  "code": {
+                    "$ref": "#/definitions/oauth-grant/definitions/code"
+                  },
+                  "type": {
+                    "$ref": "#/definitions/oauth-grant/definitions/type"
+                  }
+                }
+              },
+              "refresh_token": {
+                "type": [
+                  "object"
+                ],
+                "properties": {
+                  "token": {
+                    "$ref": "#/definitions/oauth-token/definitions/token"
+                  }
+                }
+              }
+            },
+            "required": [
+              "grant",
+              "client",
+              "refresh_token"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-token"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Revoke OAuth access token.",
+          "href": "/oauth/tokens/{(%23%2Fdefinitions%2Foauth-token%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-token"
+          },
+          "title": "Delete"
+        }
+      ],
+      "properties": {
+        "access_token": {
+          "description": "current access token",
+          "properties": {
+            "expires_in": {
+              "$ref": "#/definitions/oauth-token/definitions/expires_in"
+            },
+            "id": {
+              "$ref": "#/definitions/oauth-token/definitions/id"
+            },
+            "token": {
+              "$ref": "#/definitions/oauth-token/definitions/token"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "authorization": {
+          "description": "authorization for this set of tokens",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/oauth-authorization/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "client": {
+          "description": "OAuth client secret used to obtain token",
+          "properties": {
+            "secret": {
+              "$ref": "#/definitions/oauth-client/definitions/secret"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/oauth-token/definitions/created_at"
+        },
+        "grant": {
+          "description": "grant used on the underlying authorization",
+          "properties": {
+            "code": {
+              "$ref": "#/definitions/oauth-grant/definitions/code"
+            },
+            "type": {
+              "$ref": "#/definitions/oauth-grant/definitions/type"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/oauth-token/definitions/id"
+        },
+        "refresh_token": {
+          "description": "refresh token for this authorization",
+          "properties": {
+            "expires_in": {
+              "$ref": "#/definitions/oauth-token/definitions/expires_in"
+            },
+            "id": {
+              "$ref": "#/definitions/oauth-token/definitions/id"
+            },
+            "token": {
+              "$ref": "#/definitions/oauth-token/definitions/token"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "session": {
+          "description": "OAuth session using this token",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/oauth-token/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "updated_at": {
+          "$ref": "#/definitions/oauth-token/definitions/updated_at"
+        },
+        "user": {
+          "description": "Reference to the user associated with this token",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "oci-image": {
+      "description": "An OCI (Open Container Initiative) image is a standardized format for packaging and distributing containerized applications, ready to run on the platform.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - OCI Image",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of the OCI image",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "digest": {
+          "description": "unique identifier representing the content of the OCI image",
+          "example": "sha256:dc14ae5fbc1e7230e0a782bf216fb46500e210631703bcc6bab8acf2c6a23f42",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "architecture": {
+          "description": "build architecture for OCI image",
+          "example": "arm64",
+          "readOnly": false,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/oci-image/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/oci-image/definitions/digest"
+            }
+          ]
+        },
+        "base_image_name": {
+          "description": "name of the image used for the base layers of the OCI image",
+          "example": "heroku/heroku:22-cnb",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "base_top_layer": {
+          "description": "the digest of the top most layer of the base image.",
+          "example": "sha256:ea36ae5fbc1e7230e0a782bf216fb46500e210382703baa6bab8acf2c6a23f78",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "commit": {
+          "description": "identification of the code in your version control system (eg: SHA of the git HEAD)",
+          "example": "60883d9e8947a57e04dc9124f25df004866a2051",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "commit_description": {
+          "description": "an optional description of the provided commit",
+          "example": "fixed a bug with API documentation",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "image_repo": {
+          "description": "name of the image registry repository used for storage",
+          "example": "d7ba1ace-b396-4691-968c-37ae53153426/builds",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "process_type": {
+          "description": "process type information such as names and commands",
+          "readOnly": false,
+          "properties": {
+            "name": {
+              "description": "name of the process type",
+              "example": "web",
+              "type": [
+                "string"
+              ]
+            },
+            "display_cmd": {
+              "description": "the detailed command used for display purposes",
+              "example": "bundle exec puma -p $PORT",
+              "type": [
+                "string"
+              ]
+            },
+            "command": {
+              "description": "the command that will be executed",
+              "example": "/cnb/process/web",
+              "type": [
+                "string"
+              ]
+            },
+            "working_dir": {
+              "description": "working directory",
+              "example": "/worspace/webapp",
+              "type": [
+                "string"
+              ]
+            },
+            "default": {
+              "description": "true if it is the default process type",
+              "example": true,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "example": {
+            "name": "web",
+            "display_cmd": "bundle exec puma -p $PORT",
+            "command": "/cnb/process/web",
+            "working_dir": "/workspace/webapp",
+            "default": true
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "process_types": {
+          "description": "process types of the OCI image",
+          "patternProperties": {
+            "^[-\\w]{1,128}$": {
+              "$ref": "#/definitions/oci-image/definitions/process_type"
+            }
+          },
+          "example": {
+            "web": {
+              "name": "web",
+              "display_cmd": "bundle exec puma -p $PORT",
+              "command": "/cnb/process/web",
+              "working_dir": "/workspace/webapp",
+              "default": true
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "buildpack": {
+          "description": "set of executables that inspects app source code and creates a plan to build and run your image",
+          "readOnly": false,
+          "properties": {
+            "id": {
+              "description": "identifier of the buildpack",
+              "example": "heroku/ruby",
+              "type": [
+                "string"
+              ]
+            },
+            "version": {
+              "description": "version of the buildpack",
+              "example": "2.0.0",
+              "type": [
+                "string"
+              ]
+            },
+            "homepage": {
+              "description": "homepage of the buildpack",
+              "example": "https://github.com/heroku/buildpacks-ruby",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "example": {
+            "id": "heroku/ruby",
+            "version": "2.0.0",
+            "homepage": "https://github.com/heroku/buildpacks-ruby"
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "buildpacks": {
+          "description": "buildpacks of the OCI image",
+          "items": {
+            "$ref": "#/definitions/oci-image/definitions/buildpack"
+          },
+          "type": [
+            "array"
+          ]
+        },
+        "stack": {
+          "description": "stack associated to the OCI image",
+          "readOnly": false,
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id",
+              "example": "ba46bf09-7bd1-42fd-90df-a1a9a93eb4a2"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name",
+              "example": "cnb"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "description": "when the OCI image was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the OCI image was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for the OCI images of an app, filtered by identifier.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/oci-images/{(%23%2Fdefinitions%2Foci-image%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/oci-image"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Create an new OCI image of an app",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/oci-images",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "architecture": {
+                "$ref": "#/definitions/oci-image/definitions/architecture"
+              },
+              "base_image_name": {
+                "$ref": "#/definitions/oci-image/definitions/base_image_name"
+              },
+              "base_top_layer": {
+                "$ref": "#/definitions/oci-image/definitions/base_top_layer"
+              },
+              "commit": {
+                "$ref": "#/definitions/oci-image/definitions/commit"
+              },
+              "commit_description": {
+                "$ref": "#/definitions/oci-image/definitions/commit_description"
+              },
+              "image_repo": {
+                "$ref": "#/definitions/oci-image/definitions/image_repo"
+              },
+              "digest": {
+                "$ref": "#/definitions/oci-image/definitions/digest"
+              },
+              "stack": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/stack/definitions/name",
+                    "example": "cnb"
+                  },
+                  {
+                    "$ref": "#/definitions/stack/definitions/id"
+                  }
+                ]
+              },
+              "process_types": {
+                "$ref": "#/definitions/oci-image/definitions/process_types"
+              },
+              "buildpacks": {
+                "$ref": "#/definitions/oci-image/definitions/buildpacks"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/oci-image"
+          },
+          "title": "Create"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/oci-image/definitions/id"
+        },
+        "base_image_name": {
+          "$ref": "#/definitions/oci-image/definitions/base_image_name"
+        },
+        "base_top_layer": {
+          "$ref": "#/definitions/oci-image/definitions/base_top_layer"
+        },
+        "commit": {
+          "$ref": "#/definitions/oci-image/definitions/commit"
+        },
+        "commit_description": {
+          "$ref": "#/definitions/oci-image/definitions/commit_description"
+        },
+        "image_repo": {
+          "$ref": "#/definitions/oci-image/definitions/image_repo"
+        },
+        "digest": {
+          "$ref": "#/definitions/oci-image/definitions/digest"
+        },
+        "stack": {
+          "$ref": "#/definitions/oci-image/definitions/stack"
+        },
+        "process_types": {
+          "$ref": "#/definitions/oci-image/definitions/process_types"
+        },
+        "buildpacks": {
+          "$ref": "#/definitions/oci-image/definitions/buildpacks"
+        },
+        "created_at": {
+          "$ref": "#/definitions/oci-image/definitions/created_at"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/oci-image/definitions/updated_at"
+        },
+        "architecture": {
+          "$ref": "#/definitions/oci-image/definitions/architecture"
+        }
+      }
+    },
+    "password-reset": {
+      "description": "A password reset represents a in-process password reset attempt.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - PasswordReset",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when password reset was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/account/definitions/email"
+            }
+          ]
+        },
+        "password_confirmation": {
+          "description": "confirmation of the new password",
+          "example": "newpassword",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "reset_password_token": {
+          "description": "unique identifier of a password reset attempt",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Reset account's password. This will send a reset password link to the user's email address.",
+          "href": "/password-resets",
+          "method": "POST",
+          "rel": "self",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              }
+            },
+            "required": [
+              "email"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/password-reset"
+          },
+          "title": "Reset Password"
+        },
+        {
+          "description": "Complete password reset.",
+          "href": "/password-resets/{(%23%2Fdefinitions%2Fpassword-reset%2Fdefinitions%2Freset_password_token)}/actions/finalize",
+          "method": "POST",
+          "rel": "self",
+          "schema": {
+            "properties": {
+              "password": {
+                "$ref": "#/definitions/account/definitions/password"
+              },
+              "password_confirmation": {
+                "$ref": "#/definitions/password-reset/definitions/password_confirmation"
+              }
+            },
+            "required": [
+              "password",
+              "password_confirmation"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/password-reset"
+          },
+          "title": "Complete Reset Password"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/password-reset/definitions/created_at"
+        },
+        "user": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "peering-info": {
+      "description": "[Peering Info](https://devcenter.heroku.com/articles/private-space-peering) gives you the information necessary to peer an AWS VPC to a Private Space.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Peering Info",
+      "type": [
+        "object"
+      ],
+      "properties": {
+        "aws_account_id": {
+          "$ref": "#/definitions/peering/definitions/aws_account_id"
+        },
+        "aws_region": {
+          "$ref": "#/definitions/region/definitions/provider/properties/region"
+        },
+        "vpc_id": {
+          "$ref": "#/definitions/peering/definitions/vpc_id"
+        },
+        "vpc_cidr": {
+          "description": "The CIDR range of the Private Space VPC",
+          "$ref": "#/definitions/peering/definitions/cidr"
+        },
+        "dyno_cidr_blocks": {
+          "description": "The CIDR ranges that should be routed to the Private Space VPC.",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/peering/definitions/cidr"
+          }
+        },
+        "unavailable_cidr_blocks": {
+          "description": "The CIDR ranges that you must not conflict with.",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/peering/definitions/cidr"
+          }
+        },
+        "space_cidr_blocks": {
+          "description": "The CIDR ranges that should be routed to the Private Space VPC.",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/peering/definitions/cidr"
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Provides the necessary information to establish an AWS VPC Peering with your private space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/peering-info",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/peering-info"
+          },
+          "title": "Info"
+        }
+      ]
+    },
+    "peering": {
+      "description": "[Peering](https://devcenter.heroku.com/articles/private-space-peering) provides a way to peer your Private Space VPC to another AWS VPC.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Peering",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "aws_account_id": {
+          "description": "The AWS account ID of your Private Space.",
+          "example": "123456789012",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "aws_region": {
+          "description": "The AWS region of the peer connection.",
+          "example": "us-east-1",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "vpc_id": {
+          "description": "The AWS VPC ID of the peer.",
+          "example": "vpc-1234567890",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "The type of peering connection.",
+          "example": "heroku-managed",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "heroku-managed",
+            "customer-managed",
+            "unknown"
+          ]
+        },
+        "status": {
+          "description": "The status of the peering connection.",
+          "example": "pending-acceptance",
+          "enum": [
+            "initiating-request",
+            "pending-acceptance",
+            "provisioning",
+            "active",
+            "failed",
+            "expired",
+            "rejected",
+            "deleted"
+          ],
+          "type": [
+            "string"
+          ],
+          "readOnly": true
+        },
+        "pcx_id": {
+          "description": "The AWS VPC Peering Connection ID of the peering.",
+          "example": "pcx-123456789012",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "cidr": {
+          "description": "An IP address and the number of significant bits that make up the routing or networking portion.",
+          "example": "10.0.0.0/16",
+          "type": [
+            "string"
+          ]
+        },
+        "expires": {
+          "description": "When a peering connection will expire.",
+          "example": "2020-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/peering/definitions/type"
+        },
+        "pcx_id": {
+          "$ref": "#/definitions/peering/definitions/pcx_id"
+        },
+        "cidr_blocks": {
+          "description": "The CIDR blocks of the peer.",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/peering/definitions/cidr"
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/peering/definitions/status"
+        },
+        "aws_vpc_id": {
+          "$ref": "#/definitions/peering/definitions/vpc_id"
+        },
+        "aws_region": {
+          "$ref": "#/definitions/peering/definitions/aws_region"
+        },
+        "aws_account_id": {
+          "$ref": "#/definitions/peering/definitions/aws_account_id"
+        },
+        "expires": {
+          "$ref": "#/definitions/peering/definitions/expires"
+        }
+      },
+      "links": [
+        {
+          "description": "List peering connections of a private space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/peerings",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/peering"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Accept a pending peering connection with a private space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/peerings/{(%23%2Fdefinitions%2Fpeering%2Fdefinitions%2Fpcx_id)}/actions/accept",
+          "method": "POST",
+          "rel": "empty",
+          "title": "Accept",
+          "targetSchema": {
+            "$ref": "#/definitions/peering"
+          }
+        },
+        {
+          "description": "Destroy an active peering connection with a private space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/peerings/{(%23%2Fdefinitions%2Fpeering%2Fdefinitions%2Fpcx_id)}",
+          "rel": "empty",
+          "method": "DELETE",
+          "title": "Destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/peering"
+          }
+        },
+        {
+          "description": "Fetch information for existing peering connection",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/peerings/{(%23%2Fdefinitions%2Fpeering%2Fdefinitions%2Fpcx_id)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/peering"
+          },
+          "title": "Info"
+        }
+      ]
+    },
+    "permission-entity": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "An owned entity including users' permissions.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Permission Entity",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "ID of the entity.",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "type": {
+          "description": "The type of object the entity is referring to.",
+          "example": "app",
+          "readOnly": true,
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "app",
+            "space"
+          ]
+        },
+        "name": {
+          "description": "Name of the entity.",
+          "example": "polar-lake-12345",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "permissions": {
+          "description": "A list of permissions the user has on the entity.",
+          "example": "app",
+          "readOnly": true,
+          "type": [
+            "array"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List permission entities for a team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/permissions",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/permission-entity"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/permission-entity/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/permission-entity/definitions/name"
+        },
+        "team_id": {
+          "$ref": "#/definitions/team/definitions/id"
+        },
+        "type": {
+          "$ref": "#/definitions/permission-entity/definitions/type"
+        },
+        "users": {
+          "description": "Users that have access to the entity.",
+          "items": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              },
+              "id": {
+                "$ref": "#/definitions/account/definitions/id"
+              },
+              "permissions": {
+                "description": "enterprise account permissions",
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "type": [
+                    "string"
+                  ]
+                }
+              }
+            }
+          },
+          "type": [
+            "array"
+          ]
+        }
+      }
+    },
+    "pipeline-build": {
+      "description": "Information about the latest builds of apps in a pipeline. A build represents the process of transforming code into build artifacts.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Pipeline Build",
+      "type": [
+        "object"
+      ],
+      "definitions": {},
+      "properties": {
+        "app": {
+          "description": "app that the build belongs to",
+          "properties": {
+            "id": {
+              "description": "unique identifier of the app",
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "buildpacks": {
+          "$ref": "#/definitions/build/definitions/buildpacks"
+        },
+        "created_at": {
+          "description": "when the build was created",
+          "$ref": "#/definitions/build/definitions/created_at"
+        },
+        "id": {
+          "description": "unique identifier of the build",
+          "$ref": "#/definitions/build/definitions/id"
+        },
+        "output_stream_url": {
+          "description": "streaming URL of the build process output",
+          "$ref": "#/definitions/build/definitions/output_stream_url"
+        },
+        "source_blob": {
+          "description": "location of gzipped tarball of source code used to create build",
+          "properties": {
+            "checksum": {
+              "description": "an optional checksum of the gzipped tarball for verifying its integrity",
+              "example": "SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "readOnly": true,
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "url": {
+              "description": "URL where gzipped tar archive of source code for build was downloaded.",
+              "example": "https://example.com/source.tgz?token=xyz",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "version": {
+              "description": "version of the gzipped tarball",
+              "example": "v1.3.0",
+              "readOnly": true,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "version_description": {
+              "description": "version description of the gzipped tarball",
+              "example": "* Fake User: Change session key",
+              "readOnly": true,
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "release": {
+          "properties": {
+            "id": {
+              "description": "unique identifier of the release",
+              "$ref": "#/definitions/release/definitions/id"
+            }
+          },
+          "$ref": "#/definitions/build/definitions/release"
+        },
+        "slug": {
+          "description": "slug created by this build",
+          "properties": {
+            "id": {
+              "description": "unique identifier of the slug",
+              "$ref": "#/definitions/slug/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "stack": {
+          "description": "stack of the build",
+          "example": "heroku-24",
+          "$ref": "#/definitions/build/definitions/stack"
+        },
+        "status": {
+          "description": "status of the build",
+          "$ref": "#/definitions/build/definitions/status"
+        },
+        "updated_at": {
+          "description": "when the build was updated",
+          "$ref": "#/definitions/build/definitions/updated_at"
+        },
+        "user": {
+          "description": "user that started the build",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List latest builds for each app in a pipeline",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/latest-builds",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/pipeline-build"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ]
+    },
+    "pipeline-config-var": {
+      "description": "Pipeline config vars in Heroku CI and review apps used to manage the configuration information for a pipeline.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Pipeline Config Vars",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "config_vars": {
+          "additionalProperties": false,
+          "description": "hash of config vars",
+          "example": {
+            "FOO": "bar",
+            "BAZ": "qux"
+          },
+          "patternProperties": {
+            "^[\\w\\.\\:\\[\\]]+$": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "properties": {
+        "[\"NAME\"]: [\"value\"]": {
+          "type": [
+            "object"
+          ],
+          "description": "user-defined config var name and value",
+          "example": {
+            "FOO": "bar"
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Get config-vars for a pipeline stage.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/stage/{(%23%2Fdefinitions%2Fpipeline-coupling%2Fdefinitions%2Fstage)}/config-vars",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-config-var/definitions/config_vars"
+          },
+          "title": "Info for App"
+        },
+        {
+          "description": "Update config-vars for a pipeline stage. You can update existing config-vars by setting them again, and remove by setting it to `null`.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/stage/{(%23%2Fdefinitions%2Fpipeline-coupling%2Fdefinitions%2Fstage)}/config-vars",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "additionalProperties": false,
+            "description": "hash of config changes – update values or delete by seting it to `null`",
+            "example": {
+              "FOO": "bar",
+              "BAZ": "qux"
+            },
+            "patternProperties": {
+              "^[\\w\\.\\:\\[\\]]+$": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-config-var/definitions/config_vars"
+          },
+          "title": "Update"
+        }
+      ],
+      "example": {
+        "FOO": "bar",
+        "BAZ": "qux"
+      },
+      "patternProperties": {
+        "^\\w+$": {
+          "type": [
+            "string"
+          ]
+        }
+      }
+    },
+    "pipeline-coupling": {
+      "description": "Information about an app's coupling to a pipeline",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "title": "Heroku Platform API - Pipeline Coupling",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when pipeline coupling was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of pipeline coupling",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/pipeline-coupling/definitions/id"
+            }
+          ]
+        },
+        "stage": {
+          "description": "target pipeline stage",
+          "example": "production",
+          "enum": [
+            "test",
+            "review",
+            "development",
+            "staging",
+            "production"
+          ],
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when pipeline coupling was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List couplings for a pipeline",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/pipeline-couplings",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/pipeline-coupling"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Pipeline"
+        },
+        {
+          "description": "List pipeline couplings for the current user.",
+          "href": "/users/~/pipeline-couplings",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/pipeline-coupling"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Current User"
+        },
+        {
+          "description": "List pipeline couplings.",
+          "href": "/pipeline-couplings",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/pipeline-coupling"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List pipeline couplings for a team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/pipeline-couplings",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/pipeline-coupling"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
+        },
+        {
+          "description": "Create a new pipeline coupling.",
+          "href": "/pipeline-couplings",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "app": {
+                "$ref": "#/definitions/app/definitions/identity"
+              },
+              "pipeline": {
+                "$ref": "#/definitions/pipeline/definitions/id"
+              },
+              "stage": {
+                "$ref": "#/definitions/pipeline-coupling/definitions/stage"
+              }
+            },
+            "required": [
+              "app",
+              "pipeline",
+              "stage"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-coupling"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Info for an existing pipeline coupling.",
+          "href": "/pipeline-couplings/{(%23%2Fdefinitions%2Fpipeline-coupling%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-coupling"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Delete an existing pipeline coupling.",
+          "href": "/pipeline-couplings/{(%23%2Fdefinitions%2Fpipeline-coupling%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "delete",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-coupling"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Update an existing pipeline coupling.",
+          "href": "/pipeline-couplings/{(%23%2Fdefinitions%2Fpipeline-coupling%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "stage": {
+                "$ref": "#/definitions/pipeline-coupling/definitions/stage"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-coupling"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Info for an existing pipeline coupling.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/pipeline-couplings",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-coupling"
+          },
+          "title": "Info By App"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "app involved in the pipeline coupling",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/pipeline-coupling/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/pipeline-coupling/definitions/id"
+        },
+        "pipeline": {
+          "description": "pipeline involved in the coupling",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "stage": {
+          "$ref": "#/definitions/pipeline-coupling/definitions/stage"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/pipeline-coupling/definitions/updated_at"
+        }
+      }
+    },
+    "pipeline-deployment": {
+      "description": "Information about the latest deployment of each app in a pipeline. A deployment is the process of moving the build artifacts to a target environment.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Pipeline Deployment",
+      "type": [
+        "object"
+      ],
+      "$ref": "#/definitions/release",
+      "properties": {
+        "addon_plan_names": {
+          "description": "add-on plans installed on the app for this deployment",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/plan/definitions/name"
+          }
+        },
+        "artifacts": {
+          "$ref": "#/definitions/release/definitions/artifact"
+        },
+        "app": {
+          "description": "app involved in the deployment",
+          "properties": {
+            "name": {
+              "description": "unique name of the app",
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "description": "unique identifier of the app",
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "description": "when the deployment was created",
+          "$ref": "#/definitions/release/definitions/created_at"
+        },
+        "description": {
+          "description": "description of changes in this deployment",
+          "$ref": "#/definitions/release/definitions/description"
+        },
+        "id": {
+          "description": "unique identifier of the deployment",
+          "$ref": "#/definitions/release/definitions/id"
+        },
+        "updated_at": {
+          "description": "when the deployment was updated",
+          "$ref": "#/definitions/release/definitions/updated_at"
+        },
+        "slug": {
+          "description": "slug running in this deployment",
+          "properties": {
+            "id": {
+              "description": "unique identifier of the slug",
+              "$ref": "#/definitions/slug/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "status": {
+          "description": "current status of the deployment",
+          "$ref": "#/definitions/release/definitions/status"
+        },
+        "user": {
+          "description": "user that created the deployment",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "version": {
+          "description": "unique version assigned to the deployment",
+          "$ref": "#/definitions/release/definitions/version"
+        },
+        "current": {
+          "description": "indicates if this deployment is the current one for the app",
+          "$ref": "#/definitions/release/definitions/current"
+        },
+        "output_stream_url": {
+          "description": "streaming URL for the release command output",
+          "$ref": "#/definitions/release/definitions/output_stream_url"
+        },
+        "eligible_for_rollback": {
+          "description": "indicates if this deployment is eligible for rollback",
+          "$ref": "#/definitions/release/definitions/eligible_for_rollback"
+        }
+      },
+      "links": [
+        {
+          "description": "List latest deployments for each app in a pipeline. A deployment is a release that changed your source slug, container image, or Heroku processes.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/latest-deployments",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/release"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ]
+    },
+    "pipeline-promotion-target": {
+      "description": "Promotion targets represent an individual app being promoted to",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Pipeline Promotion Target",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "error_message": {
+          "description": "an error message for why the promotion failed",
+          "example": "User does not have access to that app",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of promotion target",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/pipeline-promotion-target/definitions/id"
+            }
+          ]
+        },
+        "status": {
+          "description": "status of promotion",
+          "example": "pending",
+          "readOnly": true,
+          "enum": [
+            "pending",
+            "succeeded",
+            "failed"
+          ],
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List promotion targets belonging to an existing promotion.",
+          "href": "/pipeline-promotions/{(%23%2Fdefinitions%2Fpipeline-promotion%2Fdefinitions%2Fid)}/promotion-targets",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/pipeline-promotion-target"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "the app which was promoted to",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "error_message": {
+          "$ref": "#/definitions/pipeline-promotion-target/definitions/error_message"
+        },
+        "id": {
+          "$ref": "#/definitions/pipeline-promotion-target/definitions/id"
+        },
+        "pipeline_promotion": {
+          "description": "the promotion which the target belongs to",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline-promotion/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "release": {
+          "description": "the release which was created on the target app",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/release/definitions/id"
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/pipeline-promotion-target/definitions/status"
+        }
+      }
+    },
+    "pipeline-promotion": {
+      "description": "Promotions allow you to move code from an app in a pipeline to all targets",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Pipeline Promotion",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when promotion was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of promotion",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/pipeline-promotion/definitions/id"
+            }
+          ]
+        },
+        "status": {
+          "description": "status of promotion",
+          "example": "pending",
+          "readOnly": true,
+          "enum": [
+            "pending",
+            "completed"
+          ],
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when promotion was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new promotion.",
+          "href": "/pipeline-promotions",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "pipeline": {
+                "description": "pipeline involved in the promotion",
+                "properties": {
+                  "id": {
+                    "$ref": "#/definitions/pipeline/definitions/id"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": [
+                  "object"
+                ]
+              },
+              "source": {
+                "description": "the app being promoted from",
+                "properties": {
+                  "app": {
+                    "description": "the app which was promoted from",
+                    "properties": {
+                      "id": {
+                        "$ref": "#/definitions/app/definitions/id"
+                      }
+                    },
+                    "strictProperties": true,
+                    "type": [
+                      "object"
+                    ]
+                  }
+                },
+                "type": [
+                  "object"
+                ]
+              },
+              "targets": {
+                "items": {
+                  "properties": {
+                    "app": {
+                      "description": "the app is being promoted to",
+                      "properties": {
+                        "id": {
+                          "$ref": "#/definitions/app/definitions/id"
+                        }
+                      },
+                      "strictProperties": true,
+                      "type": [
+                        "object"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "object"
+                  ]
+                },
+                "type": [
+                  "array"
+                ]
+              }
+            },
+            "required": [
+              "pipeline",
+              "source",
+              "targets"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-promotion"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Info for existing pipeline promotion.",
+          "href": "/pipeline-promotions/{(%23%2Fdefinitions%2Fpipeline-promotion%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-promotion"
+          },
+          "title": "Info"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/pipeline-promotion/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/pipeline-promotion/definitions/id"
+        },
+        "pipeline": {
+          "description": "the pipeline which the promotion belongs to",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "source": {
+          "description": "the app being promoted from",
+          "properties": {
+            "app": {
+              "description": "the app which was promoted from",
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/app/definitions/id"
+                }
+              },
+              "strictProperties": true,
+              "type": [
+                "object"
+              ]
+            },
+            "release": {
+              "description": "the release used to promoted from",
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/release/definitions/id"
+                }
+              },
+              "type": [
+                "object"
+              ]
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/pipeline-promotion/definitions/status"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/pipeline-promotion/definitions/updated_at"
+        }
+      }
+    },
+    "pipeline-release": {
+      "description": "Information about the latest release of each app in a pipeline. A release makes a deployment available to end-users.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Pipeline Release",
+      "type": [
+        "object"
+      ],
+      "properties": {
+        "addon_plan_names": {
+          "description": "add-on plans installed on the app for this release",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/plan/definitions/name"
+          }
+        },
+        "artifacts": {
+          "$ref": "#/definitions/release/definitions/artifact"
+        },
+        "app": {
+          "description": "app involved in the release",
+          "properties": {
+            "name": {
+              "description": "unique name of the app",
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "description": "unique identifier of the app",
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "description": "when the release was created",
+          "$ref": "#/definitions/release/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/release/definitions/description"
+        },
+        "id": {
+          "description": "unique identifier of the release",
+          "$ref": "#/definitions/release/definitions/id"
+        },
+        "updated_at": {
+          "description": "when the release was updated",
+          "$ref": "#/definitions/release/definitions/updated_at"
+        },
+        "slug": {
+          "description": "slug running in the release",
+          "properties": {
+            "id": {
+              "description": "unique identifier of the slug",
+              "$ref": "#/definitions/slug/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/release/definitions/status"
+        },
+        "user": {
+          "description": "user that created the release",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "version": {
+          "$ref": "#/definitions/release/definitions/version"
+        },
+        "current": {
+          "description": "indicates if this release is the current one for the app",
+          "$ref": "#/definitions/release/definitions/current"
+        },
+        "output_stream_url": {
+          "description": "streaming URL of the build process output",
+          "$ref": "#/definitions/release/definitions/output_stream_url"
+        },
+        "eligible_for_rollback": {
+          "$ref": "#/definitions/release/definitions/eligible_for_rollback"
+        }
+      },
+      "links": [
+        {
+          "description": "List latest releases for each app in a pipeline",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/latest-releases",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/release"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ]
+    },
+    "pipeline-stack": {
+      "description": "A pipeline's stack is determined by the apps in the pipeline. This is used during creation of CI and Review Apps that have no stack defined in app.json",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": false,
+      "title": "Heroku Platform API - Pipeline Stack",
+      "type": [
+        "object"
+      ],
+      "links": [
+        {
+          "description": "The stack for a given pipeline, used for CI and Review Apps that have no stack defined in app.json.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/pipeline-stack",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-stack"
+          },
+          "title": "Default Stack"
+        }
+      ],
+      "properties": {
+        "stack": {
+          "description": "identity of the stack that will be used for new builds without a stack defined in CI and Review Apps",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      }
+    },
+    "pipeline-transfer": {
+      "description": "A pipeline transfer is the process of changing pipeline ownership along with the contained apps.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": false,
+      "title": "Heroku Platform API - Pipeline Transfer",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "new_owner": {
+          "description": "New owner of the pipeline.",
+          "$ref": "#/definitions/pipeline/definitions/owner",
+          "type": [
+            "object"
+          ]
+        },
+        "previous_owner": {
+          "description": "Previous owner of the pipeline.",
+          "$ref": "#/definitions/pipeline/definitions/owner",
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new pipeline transfer.",
+          "href": "/pipeline-transfers",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "pipeline": {
+                "description": "The pipeline to transfer",
+                "properties": {
+                  "id": {
+                    "$ref": "#/definitions/pipeline/definitions/id"
+                  }
+                },
+                "type": [
+                  "object"
+                ]
+              },
+              "new_owner": {
+                "description": "New pipeline owner",
+                "properties": {
+                  "id": {
+                    "description": "unique identifier of a pipeline owner",
+                    "example": "01234567-89ab-cdef-0123-456789abcdef",
+                    "format": "uuid",
+                    "type": [
+                      "string"
+                    ]
+                  },
+                  "type": {
+                    "description": "type of pipeline owner",
+                    "example": "team",
+                    "pattern": "(^team$|^user$)",
+                    "type": [
+                      "string"
+                    ]
+                  }
+                },
+                "type": [
+                  "object"
+                ]
+              }
+            },
+            "required": [
+              "pipeline",
+              "new_owner"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-transfer"
+          },
+          "title": "Create"
+        }
+      ],
+      "properties": {
+        "pipeline": {
+          "description": "pipeline being transferred",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "previous_owner": {
+          "$ref": "#/definitions/pipeline-transfer/definitions/previous_owner"
+        },
+        "new_owner": {
+          "$ref": "#/definitions/pipeline-transfer/definitions/new_owner"
+        }
+      }
+    },
+    "pipeline": {
+      "description": "A pipeline allows grouping of apps into different stages.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": false,
+      "title": "Heroku Platform API - Pipeline",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when pipeline was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of pipeline",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/pipeline/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/pipeline/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "name of pipeline",
+          "example": "example",
+          "pattern": "^[a-z][a-z0-9-]{2,29}$",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "owner": {
+          "description": "Owner of a pipeline.",
+          "definitions": {
+            "id": {
+              "description": "unique identifier of a pipeline owner",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": false,
+              "type": [
+                "string"
+              ]
+            },
+            "type": {
+              "description": "type of pipeline owner",
+              "example": "team",
+              "pattern": "(^team$|^user$)",
+              "readOnly": false,
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "links": [],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/owner/definitions/id"
+            },
+            "type": {
+              "$ref": "#/definitions/pipeline/definitions/owner/definitions/type"
+            }
+          },
+          "required": [
+            "id",
+            "type"
+          ],
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "updated_at": {
+          "description": "when pipeline was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "generation": {
+          "description": "the generation of the Heroku platform for this pipeline",
+          "definitions": {
+            "id": {
+              "description": "unique identifier of the generation of the Heroku platform for this pipeline",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "identity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/pipeline/definitions/generation/definitions/id"
+                },
+                {
+                  "$ref": "#/definitions/pipeline/definitions/generation/definitions/name"
+                }
+              ]
+            },
+            "name": {
+              "description": "unique name of the generation of the Heroku platform for this pipeline",
+              "example": "cedar",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/generation/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/pipeline/definitions/generation/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new pipeline.",
+          "href": "/pipelines",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/pipeline/definitions/name"
+              },
+              "owner": {
+                "description": "Pipeline owner",
+                "$ref": "#/definitions/pipeline/definitions/owner",
+                "type": [
+                  "object",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Info for existing pipeline.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Delete an existing pipeline.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}",
+          "method": "DELETE",
+          "rel": "delete",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Update an existing pipeline.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/pipeline/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "List existing pipelines.",
+          "href": "/pipelines",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/pipeline"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/pipeline/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/pipeline/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/pipeline/definitions/name"
+        },
+        "owner": {
+          "$ref": "#/definitions/pipeline/definitions/owner"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/pipeline/definitions/updated_at"
+        },
+        "generation": {
+          "$ref": "#/definitions/pipeline/definitions/generation"
+        }
+      }
+    },
+    "plan": {
+      "description": "Plans represent different configurations of add-ons that may be added to apps. Endpoints under add-on services can be accessed without authentication.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Plan",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when plan was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "compliance": {
+          "description": "the compliance regimes applied to an add-on plan",
+          "example": [
+            "HIPAA"
+          ],
+          "readOnly": false,
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/plan/definitions/regime"
+          }
+        },
+        "default": {
+          "description": "whether this plan is the default for its add-on service",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "description": {
+          "description": "description of plan",
+          "example": "Heroku Postgres Dev",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "human_name": {
+          "description": "human readable name of the add-on plan",
+          "example": "Dev",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this plan",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "installable_inside_private_network": {
+          "description": "whether this plan is installable to a Private Spaces app",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "installable_outside_private_network": {
+          "description": "whether this plan is installable to a Common Runtime app",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/plan/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/plan/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of this plan",
+          "example": "heroku-postgresql:dev",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "regime": {
+          "description": "compliance requirements an add-on plan must adhere to",
+          "readOnly": true,
+          "example": "HIPAA",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "HIPAA",
+            "PCI"
+          ]
+        },
+        "cents": {
+          "description": "price in cents per unit of plan",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "contract": {
+          "description": "price is negotiated in a contract outside of monthly add-on billing",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "unit": {
+          "description": "unit of price for plan",
+          "example": "month",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "space_default": {
+          "description": "whether this plan is the default for apps in Private Spaces",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "state": {
+          "description": "release status for plan",
+          "example": "public",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when plan was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "visible": {
+          "description": "whether this plan is publicly visible",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing plan.",
+          "href": "/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/plan"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Info for existing plan by Add-on.",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/plan"
+          },
+          "title": "Info By Add-on"
+        },
+        {
+          "description": "List existing plans by Add-on.",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/plan"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Add-on"
+        }
+      ],
+      "properties": {
+        "addon_service": {
+          "description": "identity of add-on service",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/add-on-service/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/add-on-service/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/plan/definitions/created_at"
+        },
+        "compliance": {
+          "$ref": "#/definitions/plan/definitions/compliance"
+        },
+        "default": {
+          "$ref": "#/definitions/plan/definitions/default"
+        },
+        "description": {
+          "$ref": "#/definitions/plan/definitions/description"
+        },
+        "human_name": {
+          "$ref": "#/definitions/plan/definitions/human_name"
+        },
+        "id": {
+          "$ref": "#/definitions/plan/definitions/id"
+        },
+        "installable_inside_private_network": {
+          "$ref": "#/definitions/plan/definitions/installable_inside_private_network"
+        },
+        "installable_outside_private_network": {
+          "$ref": "#/definitions/plan/definitions/installable_outside_private_network"
+        },
+        "name": {
+          "$ref": "#/definitions/plan/definitions/name"
+        },
+        "price": {
+          "description": "price",
+          "properties": {
+            "cents": {
+              "$ref": "#/definitions/plan/definitions/cents"
+            },
+            "contract": {
+              "$ref": "#/definitions/plan/definitions/contract"
+            },
+            "unit": {
+              "$ref": "#/definitions/plan/definitions/unit"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "space_default": {
+          "$ref": "#/definitions/plan/definitions/space_default"
+        },
+        "state": {
+          "$ref": "#/definitions/plan/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/plan/definitions/updated_at"
+        },
+        "visible": {
+          "$ref": "#/definitions/plan/definitions/visible"
+        }
+      }
+    },
+    "rate-limit": {
+      "description": "Rate Limit represents the number of request tokens each account holds. Requests to this endpoint do not count towards the rate limit.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Rate Limit",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {},
+        "remaining": {
+          "description": "allowed requests remaining in current interval",
+          "example": 2399,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for rate limits.",
+          "href": "/account/rate-limits",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/rate-limit"
+          },
+          "title": "Info"
+        }
+      ],
+      "properties": {
+        "remaining": {
+          "$ref": "#/definitions/rate-limit/definitions/remaining"
+        }
+      }
+    },
+    "region": {
+      "description": "A region represents a geographic location in which your application may run.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Region",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "country": {
+          "description": "country where the region exists",
+          "example": "United States",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when region was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of region",
+          "example": "United States",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of region",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/region/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/region/definitions/name"
+            }
+          ]
+        },
+        "locale": {
+          "description": "area in the country where the region exists",
+          "example": "Virginia",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "unique name of region",
+          "example": "us",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "private_capable": {
+          "description": "whether or not region is available for creating a Private Space",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "provider": {
+          "description": "provider of underlying substrate",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "name": {
+              "description": "name of provider",
+              "example": "amazon-web-services",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "region": {
+              "description": "region name used by provider",
+              "example": "us-east-1",
+              "readOnly": true,
+              "type": [
+                "string"
+              ],
+              "enum": [
+                "ap-south-1",
+                "eu-west-1",
+                "ap-southeast-1",
+                "ap-southeast-2",
+                "eu-central-1",
+                "eu-west-2",
+                "ap-northeast-2",
+                "ap-northeast-1",
+                "us-east-1",
+                "sa-east-1",
+                "us-west-1",
+                "us-west-2",
+                "ca-central-1"
+              ]
+            }
+          },
+          "readOnly": true
+        },
+        "updated_at": {
+          "description": "when region was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing region.",
+          "href": "/regions/{(%23%2Fdefinitions%2Fregion%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/region"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing regions.",
+          "href": "/regions",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/region"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "country": {
+          "$ref": "#/definitions/region/definitions/country"
+        },
+        "created_at": {
+          "$ref": "#/definitions/region/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/region/definitions/description"
+        },
+        "id": {
+          "$ref": "#/definitions/region/definitions/id"
+        },
+        "locale": {
+          "$ref": "#/definitions/region/definitions/locale"
+        },
+        "name": {
+          "$ref": "#/definitions/region/definitions/name"
+        },
+        "private_capable": {
+          "$ref": "#/definitions/region/definitions/private_capable"
+        },
+        "provider": {
+          "$ref": "#/definitions/region/definitions/provider"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/region/definitions/updated_at"
+        }
+      }
+    },
+    "release": {
+      "description": "A release represents a combination of code, config vars and add-ons for an app on Heroku.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Release",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "artifact": {
+          "description": "a build artifact for the release",
+          "properties": {
+            "type": {
+              "description": "type of artifact",
+              "example": "slug",
+              "type": [
+                "string"
+              ]
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/slug/definitions/id"
+                },
+                {
+                  "$ref": "#/definitions/oci-image/definitions/id"
+                }
+              ]
+            }
+          },
+          "readOnly": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "description": "when release was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of changes in this release",
+          "example": "Added new feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "status": {
+          "description": "current status of the release",
+          "enum": [
+            "failed",
+            "pending",
+            "succeeded"
+          ],
+          "example": "succeeded",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of release",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/release/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/release/definitions/version"
+            }
+          ]
+        },
+        "updated_at": {
+          "description": "when release was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "version": {
+          "description": "unique version assigned to the release",
+          "example": 11,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "current": {
+          "description": "indicates this release as being the current one for the app",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "output_stream_url": {
+          "description": "Release command output will be available from this URL as a stream. The stream is available as either `text/plain` or `text/event-stream`. Clients should be prepared to handle disconnects and can resume the stream by sending a `Range` header (for `text/plain`) or a `Last-Event-Id` header (for `text/event-stream`).",
+          "example": "https://release-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "eligible_for_rollback": {
+          "description": "indicates if this release is eligible for rollback",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing release.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/releases/{(%23%2Fdefinitions%2Frelease%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/release"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing releases.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/releases",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/release"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Create new release.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/releases",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "description": {
+                "$ref": "#/definitions/release/definitions/description"
+              },
+              "oci_image": {
+                "$ref": "#/definitions/oci-image/definitions/identity"
+              },
+              "slug": {
+                "$ref": "#/definitions/slug/definitions/identity"
+              }
+            },
+            "required": [
+              "slug"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/release"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Rollback to an existing release.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/releases",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "release": {
+                "$ref": "#/definitions/release/definitions/id"
+              }
+            },
+            "required": [
+              "release"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/release"
+          },
+          "title": "Rollback"
+        }
+      ],
+      "properties": {
+        "addon_plan_names": {
+          "description": "add-on plans installed on the app for this release",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/plan/definitions/name"
+          }
+        },
+        "artifacts": {
+          "description": "build artifacts for the release",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/release/definitions/artifact"
+          }
+        },
+        "app": {
+          "description": "app involved in the release",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/release/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/release/definitions/description"
+        },
+        "id": {
+          "$ref": "#/definitions/release/definitions/id"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/release/definitions/updated_at"
+        },
+        "slug": {
+          "description": "slug running in this release",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/slug/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/release/definitions/status"
+        },
+        "user": {
+          "description": "user that created the release",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "version": {
+          "$ref": "#/definitions/release/definitions/version"
+        },
+        "current": {
+          "$ref": "#/definitions/release/definitions/current"
+        },
+        "output_stream_url": {
+          "$ref": "#/definitions/release/definitions/output_stream_url"
+        },
+        "eligible_for_rollback": {
+          "$ref": "#/definitions/release/definitions/eligible_for_rollback"
+        }
+      }
+    },
+    "review-app": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Review App",
+      "description": "An ephemeral app to review a set of changes",
+      "stability": "production",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "app_setup": {
+          "readOnly": true,
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "branch": {
+          "description": "the branch of the repository which the review app is based on",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of the review app",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/review-app/definitions/id"
+            }
+          ]
+        },
+        "creator": {
+          "description": "The user who created the review app",
+          "readOnly": true,
+          "type": [
+            "object"
+          ],
+          "definitions": {
+            "id": {
+              "description": "unique identifier of a review app owner",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": false,
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "created_at": {
+          "description": "when test run was created",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "source_blob": {
+          "description": "The download location for the review app's source code",
+          "properties": {
+            "url": {
+              "description": "URL where gzipped tar archive of source code for build was downloaded.",
+              "example": "https://example.com/source.tgz?token=xyz",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "version": {
+              "description": "The version number (or SHA) of the code to build.",
+              "example": "v1.2.0",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "status": {
+          "description": "current state of the review app",
+          "enum": [
+            "pending",
+            "creating",
+            "created",
+            "deleting",
+            "deleted",
+            "errored"
+          ],
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when review app was updated",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "wait_for_ci": {
+          "description": "wait for ci before building the app",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "error_status": {
+          "description": "error message from creating the review app if any",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "message": {
+          "description": "message from creating the review app if any",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "config_vars": {
+          "additionalProperties": false,
+          "description": "hash of config vars",
+          "example": {
+            "FOO": "bar",
+            "BAZ": "qux"
+          },
+          "patternProperties": {
+            "^[\\w\\.\\:\\[\\]]+$": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "fork_repo_id": {
+          "description": "repository id of the fork the branch resides in",
+          "example": "123456",
+          "readOnly": true,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "pr_number": {
+          "description": "pull request number the review app is built for",
+          "example": 24,
+          "readOnly": true,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new review app",
+          "href": "/review-apps",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "branch": {
+                "$ref": "#/definitions/review-app/definitions/branch"
+              },
+              "pr_number": {
+                "$ref": "#/definitions/review-app/definitions/pr_number"
+              },
+              "pipeline": {
+                "$ref": "#/definitions/pipeline/definitions/id"
+              },
+              "source_blob": {
+                "$ref": "#/definitions/review-app/definitions/source_blob"
+              },
+              "environment": {
+                "$ref": "#/definitions/review-app/definitions/config_vars",
+                "description": "A set of key value pairs which will be put into the environment of the spawned review app process."
+              },
+              "fork_repo_id": {
+                "$ref": "#/definitions/review-app/definitions/fork_repo_id"
+              }
+            },
+            "required": [
+              "branch",
+              "pipeline",
+              "source_blob"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Create",
+          "targetSchema": {
+            "$ref": "#/definitions/review-app"
+          }
+        },
+        {
+          "description": "Gets an existing review app",
+          "href": "/review-apps/{(%23%2Fdefinitions%2Freview-app%2Fdefinitions%2Fid)}",
+          "method": "GET",
+          "targetSchema": {
+            "$ref": "#/definitions/review-app"
+          },
+          "title": "Get review app"
+        },
+        {
+          "description": "Delete an existing review app",
+          "href": "/review-apps/{(%23%2Fdefinitions%2Freview-app%2Fdefinitions%2Fid)}",
+          "method": "DELETE",
+          "rel": "delete",
+          "targetSchema": {
+            "$ref": "#/definitions/review-app"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Get a review app using the associated app_id",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/review-app",
+          "method": "GET",
+          "title": "Get review app by app_id",
+          "targetSchema": {
+            "$ref": "#/definitions/review-app"
+          }
+        },
+        {
+          "description": "List review apps for a pipeline",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/review-apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/review-app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "the Heroku app associated to this review app",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "app_setup": {
+          "description": "the app setup for this review app",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app-setup/definitions/id"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "branch": {
+          "$ref": "#/definitions/review-app/definitions/branch"
+        },
+        "created_at": {
+          "$ref": "#/definitions/review-app/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/review-app/definitions/id"
+        },
+        "pipeline": {
+          "description": "the pipeline which this review app belongs to",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/review-app/definitions/status"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/review-app/definitions/updated_at"
+        },
+        "creator": {
+          "$ref": "#/definitions/review-app/definitions/creator"
+        },
+        "wait_for_ci": {
+          "$ref": "#/definitions/review-app/definitions/wait_for_ci"
+        },
+        "error_status": {
+          "$ref": "#/definitions/review-app/definitions/error_status"
+        },
+        "message": {
+          "$ref": "#/definitions/review-app/definitions/message"
+        },
+        "fork_repo": {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/review-app/definitions/fork_repo_id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "pr_number": {
+          "$ref": "#/definitions/review-app/definitions/pr_number"
+        }
+      }
+    },
+    "review-app-config": {
+      "description": "Review apps can be configured for pipelines.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": false,
+      "title": "Heroku Platform API - Review App Configuration",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of pipeline",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "repo": {
+          "description": "repository name",
+          "example": "heroku/homebrew-brew",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "automatic_review_apps": {
+          "description": "enable automatic review apps for pull requests",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "repo_id": {
+          "description": "repository id",
+          "example": "123456",
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "destroy_stale_apps": {
+          "description": "automatically destroy review apps when they haven't been deployed for a number of days",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "stale_days": {
+          "description": "number of days without a deployment after which to consider a review app stale",
+          "example": "5",
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "wait_for_ci": {
+          "description": "If true, review apps are created only when CI passes",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "base_name": {
+          "description": "A unique prefix that will be used to create review app names",
+          "example": "singular-app",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "deploy_target": {
+          "description": "the deploy target for the review apps of a pipeline",
+          "definitions": {
+            "id": {
+              "description": "unique identifier of deploy target",
+              "example": "us",
+              "pattern": "(^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$|^[a-z]{2}$)",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "type": {
+              "description": "type of deploy target",
+              "example": "region",
+              "pattern": "(^space$|^region$)",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "links": [],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/review-app-config/definitions/deploy_target/definitions/id"
+            },
+            "type": {
+              "$ref": "#/definitions/review-app-config/definitions/deploy_target/definitions/type"
+            }
+          },
+          "required": [
+            "id",
+            "type"
+          ],
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Enable review apps for a pipeline",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/review-app-config",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "repo": {
+                "$ref": "#/definitions/review-app-config/definitions/repo",
+                "description": "The full_name of the repository that you want enable review-apps from."
+              },
+              "automatic_review_apps": {
+                "$ref": "#/definitions/review-app-config/definitions/automatic_review_apps",
+                "description": "If true, this will trigger the creation of review apps when pull-requests are opened in the repo."
+              },
+              "destroy_stale_apps": {
+                "$ref": "#/definitions/review-app-config/definitions/destroy_stale_apps",
+                "description": "If true, this will trigger automatic deletion of review apps when they're stale"
+              },
+              "stale_days": {
+                "$ref": "#/definitions/review-app-config/definitions/stale_days",
+                "description": "If destroy_stale_apps is true, then apps will be destroyed after this many days"
+              },
+              "deploy_target": {
+                "$ref": "#/definitions/review-app-config/definitions/deploy_target",
+                "description": "Provides a key/value pair to specify whether to use a common runtime or a private space"
+              },
+              "wait_for_ci": {
+                "$ref": "#/definitions/review-app-config/definitions/wait_for_ci",
+                "description": "If true, review apps will only be created when CI passes"
+              },
+              "base_name": {
+                "$ref": "#/definitions/review-app-config/definitions/base_name",
+                "description": "A unique prefix that will be used to create review app names"
+              }
+            },
+            "required": [
+              "repo"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Enable",
+          "targetSchema": {
+            "$ref": "#/definitions/review-app-config"
+          }
+        },
+        {
+          "description": "Get review apps configuration for a pipeline",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/review-app-config",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info",
+          "targetSchema": {
+            "$ref": "#/definitions/review-app-config"
+          }
+        },
+        {
+          "description": "Update review app configuration for a pipeline",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/review-app-config",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "automatic_review_apps": {
+                "$ref": "#/definitions/review-app-config/definitions/automatic_review_apps",
+                "description": "If true, this will trigger the creation of review apps when pull-requests are opened in the repo"
+              },
+              "destroy_stale_apps": {
+                "$ref": "#/definitions/review-app-config/definitions/destroy_stale_apps",
+                "description": "If true, this will trigger automatic deletion of review apps when they're stale"
+              },
+              "stale_days": {
+                "$ref": "#/definitions/review-app-config/definitions/stale_days",
+                "description": "If destroy_stale_apps is true, then apps will be destroyed after this many days"
+              },
+              "deploy_target": {
+                "$ref": "#/definitions/review-app-config/definitions/deploy_target",
+                "description": "Provides a key/value pair to specify whether to use a common runtime or a private space"
+              },
+              "wait_for_ci": {
+                "$ref": "#/definitions/review-app-config/definitions/wait_for_ci",
+                "description": "If true, review apps will only be created when CI passes"
+              },
+              "base_name": {
+                "$ref": "#/definitions/review-app-config/definitions/base_name",
+                "description": "A unique prefix that will be used to create review app names"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Update",
+          "targetSchema": {
+            "$ref": "#/definitions/review-app-config"
+          }
+        },
+        {
+          "description": "Disable review apps for a pipeline",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/review-app-config",
+          "method": "DELETE",
+          "rel": "destroy",
+          "title": "Delete",
+          "targetSchema": {
+            "$ref": "#/definitions/review-app-config"
+          }
+        }
+      ],
+      "properties": {
+        "repo": {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/review-app-config/definitions/repo_id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "automatic_review_apps": {
+          "$ref": "#/definitions/review-app-config/definitions/automatic_review_apps"
+        },
+        "deploy_target": {
+          "$ref": "#/definitions/review-app-config/definitions/deploy_target"
+        },
+        "destroy_stale_apps": {
+          "$ref": "#/definitions/review-app-config/definitions/destroy_stale_apps"
+        },
+        "stale_days": {
+          "$ref": "#/definitions/review-app-config/definitions/stale_days"
+        },
+        "pipeline_id": {
+          "$ref": "#/definitions/review-app-config/definitions/id"
+        },
+        "wait_for_ci": {
+          "$ref": "#/definitions/review-app-config/definitions/wait_for_ci"
+        },
+        "base_name": {
+          "$ref": "#/definitions/review-app-config/definitions/base_name"
+        }
+      }
+    },
+    "slug": {
+      "description": "A slug is a snapshot of your application code that is ready to run on the platform.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Slug",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "buildpack_provided_description": {
+          "description": "description from buildpack of slug",
+          "example": "Ruby/Rack",
+          "readOnly": false,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "checksum": {
+          "description": "an optional checksum of the slug for verifying its integrity",
+          "example": "SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "commit": {
+          "description": "identification of the code with your version control system (eg: SHA of the git HEAD)",
+          "example": "60883d9e8947a57e04dc9124f25df004866a2051",
+          "readOnly": false,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "commit_description": {
+          "description": "an optional description of the provided commit",
+          "example": "fixed a bug with API documentation",
+          "readOnly": false,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when slug was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of slug",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/slug/definitions/id"
+            }
+          ]
+        },
+        "method": {
+          "description": "method to be used to interact with the slug blob",
+          "example": "GET",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "process_types": {
+          "additionalProperties": false,
+          "description": "hash mapping process type names to their respective command",
+          "example": {
+            "web": "./bin/web -p $PORT"
+          },
+          "patternProperties": {
+            "^[-\\w]{1,128}$": {
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "readOnly": false,
+          "type": [
+            "object"
+          ]
+        },
+        "size": {
+          "default": null,
+          "description": "size of slug, in bytes",
+          "example": 2048,
+          "readOnly": true,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "updated_at": {
+          "description": "when slug was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "url": {
+          "description": "URL to interact with the slug blob",
+          "example": "https://api.heroku.com/slugs/1234.tgz",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing slug.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/slugs/{(%23%2Fdefinitions%2Fslug%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/slug"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Create a new slug. For more information please refer to [Deploying Slugs using the Platform API](https://devcenter.heroku.com/articles/platform-api-deploying-slugs).",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/slugs",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "buildpack_provided_description": {
+                "$ref": "#/definitions/slug/definitions/buildpack_provided_description"
+              },
+              "checksum": {
+                "$ref": "#/definitions/slug/definitions/checksum"
+              },
+              "commit": {
+                "$ref": "#/definitions/slug/definitions/commit"
+              },
+              "commit_description": {
+                "$ref": "#/definitions/slug/definitions/commit_description"
+              },
+              "process_types": {
+                "$ref": "#/definitions/slug/definitions/process_types"
+              },
+              "stack": {
+                "$ref": "#/definitions/stack/definitions/identity"
+              }
+            },
+            "required": [
+              "process_types"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/slug",
+            "example": {
+              "blob": {
+                "method": "PUT",
+                "url": "https://api.heroku.com/slugs/1234.tgz"
+              },
+              "buildpack_provided_description": "Ruby/Rack",
+              "checksum": "SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "commit": "60883d9e8947a57e04dc9124f25df004866a2051",
+              "commit_description": "fixed a bug with API documentation",
+              "created_at": "2012-01-01T12:00:00Z",
+              "id": "01234567-89ab-cdef-0123-456789abcdef",
+              "process_types": {
+                "web": "./bin/web -p $PORT"
+              },
+              "size": 2048,
+              "stack": {
+                "id": "01234567-89ab-cdef-0123-456789abcdef",
+                "name": "heroku-18"
+              },
+              "updated_at": "2012-01-01T12:00:00Z"
+            }
+          },
+          "title": "Create"
+        }
+      ],
+      "properties": {
+        "blob": {
+          "description": "pointer to the url where clients can fetch or store the actual release binary",
+          "properties": {
+            "method": {
+              "$ref": "#/definitions/slug/definitions/method"
+            },
+            "url": {
+              "$ref": "#/definitions/slug/definitions/url"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "buildpack_provided_description": {
+          "$ref": "#/definitions/slug/definitions/buildpack_provided_description"
+        },
+        "checksum": {
+          "$ref": "#/definitions/slug/definitions/checksum"
+        },
+        "commit": {
+          "$ref": "#/definitions/slug/definitions/commit"
+        },
+        "commit_description": {
+          "$ref": "#/definitions/slug/definitions/commit_description"
+        },
+        "created_at": {
+          "$ref": "#/definitions/slug/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/slug/definitions/id"
+        },
+        "process_types": {
+          "$ref": "#/definitions/slug/definitions/process_types"
+        },
+        "size": {
+          "$ref": "#/definitions/slug/definitions/size"
+        },
+        "stack": {
+          "description": "identity of slug stack",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "updated_at": {
+          "$ref": "#/definitions/slug/definitions/updated_at"
+        }
+      }
+    },
+    "sms-number": {
+      "description": "SMS numbers are used for recovery on accounts with two-factor authentication enabled.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - SMS Number",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "sms_number": {
+          "$ref": "#/definitions/account/definitions/sms_number"
+        }
+      },
+      "links": [
+        {
+          "description": "Recover an account using an SMS recovery code",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/sms-number",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/sms-number"
+          },
+          "title": "SMS Number"
+        },
+        {
+          "description": "Recover an account using an SMS recovery code",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/sms-number/actions/recover",
+          "method": "POST",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/sms-number"
+          },
+          "title": "Recover"
+        },
+        {
+          "description": "Confirm an SMS number change with a confirmation code",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/sms-number/actions/confirm",
+          "method": "POST",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/sms-number"
+          },
+          "title": "Confirm"
+        }
+      ],
+      "properties": {
+        "sms_number": {
+          "$ref": "#/definitions/account/definitions/sms_number"
+        }
+      }
+    },
+    "sni-endpoint": {
+      "description": "SNI Endpoint is a public address serving a custom SSL cert for HTTPS traffic, using the SNI TLS extension, to a Heroku app.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - SNI Endpoint",
+      "stability": "development",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "ca_signed?": {
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "cert_domains": {
+          "readOnly": true,
+          "type": [
+            "array"
+          ]
+        },
+        "certificate_chain": {
+          "description": "raw contents of the public certificate chain (eg: .crt or .pem file)",
+          "example": "-----BEGIN CERTIFICATE----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when endpoint was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "domains": {
+          "description": "domains associated with this SSL certificate",
+          "type": [
+            "array"
+          ],
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/domain/definitions/id"
+          }
+        },
+        "display_name": {
+          "description": "unique name for SSL certificate",
+          "example": "example",
+          "pattern": "^[a-z][a-z0-9-]{2,29}$",
+          "readOnly": false,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expires_at": {
+          "readOnly": true,
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this SNI endpoint",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/sni-endpoint/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/sni-endpoint/definitions/name"
+            }
+          ]
+        },
+        "issuer": {
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "unique name for SNI endpoint",
+          "example": "example",
+          "pattern": "^[a-z][a-z0-9-]{2,29}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "private_key": {
+          "description": "contents of the private key (eg .key file)",
+          "example": "-----BEGIN RSA PRIVATE KEY----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "self_signed?": {
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "starts_at": {
+          "readOnly": true,
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "subject": {
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when SNI endpoint was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "certificate_chain": {
+                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+              },
+              "private_key": {
+                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
+              }
+            },
+            "required": [
+              "certificate_chain",
+              "private_key"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing SNI endpoints.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/sni-endpoint"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update an existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "certificate_chain": {
+                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+              },
+              "private_key": {
+                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
+              }
+            },
+            "required": [
+              "certificate_chain",
+              "private_key"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "certificate_chain": {
+          "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+        },
+        "created_at": {
+          "$ref": "#/definitions/sni-endpoint/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/sni-endpoint/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/sni-endpoint/definitions/name"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/sni-endpoint/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/sni-endpoint/definitions/display_name"
+        },
+        "domains": {
+          "$ref": "#/definitions/sni-endpoint/definitions/domains"
+        },
+        "app": {
+          "description": "application that this SSL certificate is on",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "ssl_cert": {
+          "description": "certificate provided by this endpoint",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "ca_signed?": {
+              "$ref": "#/definitions/sni-endpoint/definitions/ca_signed?"
+            },
+            "cert_domains": {
+              "$ref": "#/definitions/sni-endpoint/definitions/cert_domains"
+            },
+            "expires_at": {
+              "$ref": "#/definitions/sni-endpoint/definitions/expires_at"
+            },
+            "issuer": {
+              "$ref": "#/definitions/sni-endpoint/definitions/issuer"
+            },
+            "self_signed?": {
+              "$ref": "#/definitions/sni-endpoint/definitions/self_signed?"
+            },
+            "starts_at": {
+              "$ref": "#/definitions/sni-endpoint/definitions/starts_at"
+            },
+            "subject": {
+              "$ref": "#/definitions/sni-endpoint/definitions/subject"
+            },
+            "id": {
+              "description": "unique identifier of this SSL certificate",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "source": {
+      "description": "A source is a location for uploading and downloading an application's source code.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Source",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "get_url": {
+          "description": "URL to download the source",
+          "example": "https://api.heroku.com/sources/1234.tgz",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "put_url": {
+          "description": "URL to upload the source",
+          "example": "https://api.heroku.com/sources/1234.tgz",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create URLs for uploading and downloading source.",
+          "href": "/sources",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/source"
+          },
+          "title": "Create"
+        },
+        {
+          "deactivate_on": "2017-08-01",
+          "description": "Create URLs for uploading and downloading source. Deprecated in favor of `POST /sources`",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sources",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/source"
+          },
+          "title": "Create - Deprecated"
+        }
+      ],
+      "properties": {
+        "source_blob": {
+          "description": "pointer to the URL where clients can fetch or store the source",
+          "properties": {
+            "get_url": {
+              "$ref": "#/definitions/source/definitions/get_url"
+            },
+            "put_url": {
+              "$ref": "#/definitions/source/definitions/put_url"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "space-app-access": {
+      "description": "Space access represents the permissions a particular user has on a particular space.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "title": "Heroku Platform API - Space Access",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of the space a user has permissions on",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/space-app-access/definitions/id"
+            }
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List permissions for a given user on a given space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/space-app-access"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update an existing user's set of permissions on a space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "required": [
+              "permissions"
+            ],
+            "properties": {
+              "permissions": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "type": [
+                    "object"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": [
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/space-app-access"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "List all users and their permissions on a space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/members",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/space-app-access"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "space": {
+          "description": "space user belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/space/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/space/definitions/id"
+        },
+        "permissions": {
+          "description": "user space permissions",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "description": {
+                "type": [
+                  "string"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string"
+                ]
+              }
+            }
+          }
+        },
+        "updated_at": {
+          "$ref": "#/definitions/space/definitions/updated_at"
+        },
+        "user": {
+          "description": "identity of user account",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "space-nat": {
+      "description": "Network address translation (NAT) for stable outbound IP addresses from a space",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Space Network Address Translation",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when network address translation for a space was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "ip_v4_address": {
+          "example": "123.123.123.123",
+          "format": "ipv4",
+          "pattern": "^(([01]?\\d?\\d|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d?\\d|2[0-4]\\d|25[0-5])$",
+          "type": [
+            "string"
+          ]
+        },
+        "sources": {
+          "description": "potential IPs from which outbound network traffic will originate",
+          "readOnly": true,
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/space-nat/definitions/ip_v4_address"
+          }
+        },
+        "state": {
+          "description": "availability of network address translation for a space",
+          "enum": [
+            "disabled",
+            "updating",
+            "enabled"
+          ],
+          "example": "enabled",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when network address translation for a space was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Current state of network address translation for a space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/nat",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/space-nat"
+          },
+          "title": "Info"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/space-nat/definitions/created_at"
+        },
+        "sources": {
+          "$ref": "#/definitions/space-nat/definitions/sources"
+        },
+        "state": {
+          "$ref": "#/definitions/space-nat/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/space-nat/definitions/updated_at"
+        }
+      }
+    },
+    "space-topology": {
+      "description": "Space Topology provides you with a mechanism for viewing all the running dynos, formations and applications for a space. This is the same data thats used to power our DNS Service Discovery.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Space Topology",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "version": {
+          "description": "version of the space topology payload",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "dyno": {
+          "description": "A dyno",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/dyno/definitions/id"
+            },
+            "number": {
+              "description": "process number, e.g. 1 in web.1",
+              "example": 1,
+              "type": [
+                "integer"
+              ]
+            },
+            "private_ip": {
+              "description": "RFC1918 Address of Dyno",
+              "example": "10.0.134.42",
+              "type": [
+                "string"
+              ]
+            },
+            "hostname": {
+              "description": "localspace hostname of resource",
+              "example": "1.example-app-90210.app.localspace",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "formation": {
+          "description": "formations for application",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/formation/definitions/id"
+            },
+            "process_type": {
+              "description": "Name of process type",
+              "example": "web",
+              "type": [
+                "string"
+              ]
+            },
+            "dynos": {
+              "description": "Current dynos for application",
+              "items": {
+                "$ref": "#/definitions/space-topology/definitions/dyno"
+              },
+              "type": [
+                "array"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Current space topology",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/topology",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/space-topology"
+          },
+          "title": "Topology"
+        }
+      ],
+      "properties": {
+        "version": {
+          "$ref": "#/definitions/space-topology/definitions/version"
+        },
+        "apps": {
+          "description": "The apps within this space",
+          "type": [
+            "array"
+          ],
+          "readOnly": true,
+          "items": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "id": {
+                "$ref": "#/definitions/app/definitions/id",
+                "readOnly": true
+              },
+              "domains": {
+                "example": [
+                  "example.com",
+                  "example.net"
+                ],
+                "readOnly": true,
+                "type": [
+                  "array"
+                ]
+              },
+              "formation": {
+                "description": "formations for application",
+                "items": {
+                  "$ref": "#/definitions/space-topology/definitions/formation"
+                },
+                "type": [
+                  "array"
+                ],
+                "readOnly": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "space-transfer": {
+      "description": "Transfer spaces between enterprise teams with the same Enterprise Account.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Space Transfer",
+      "type": [
+        "object"
+      ],
+      "links": [
+        {
+          "description": "Transfer space between enterprise teams",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/transfer",
+          "method": "POST",
+          "rel": "transfer",
+          "schema": {
+            "properties": {
+              "new_owner": {
+                "$ref": "#/definitions/team/definitions/name"
+              }
+            },
+            "required": [
+              "new_owner"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/space"
+          },
+          "title": "transfer"
+        }
+      ]
+    },
+    "space": {
+      "description": "A space is an isolated, highly available, secure app execution environment.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Space",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when space was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of space",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/space/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/space/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of space",
+          "example": "nasa",
+          "readOnly": false,
+          "pattern": "^[a-z0-9](?:[a-z0-9]|-(?!-))+[a-z0-9]$",
+          "type": [
+            "string"
+          ]
+        },
+        "shield": {
+          "description": "true if this space has shield enabled",
+          "readOnly": true,
+          "example": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "state": {
+          "description": "availability of this space",
+          "enum": [
+            "allocating",
+            "allocated",
+            "deleting"
+          ],
+          "example": "allocated",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when space was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "log_drain_url": {
+          "description": "URL to which all apps will drain logs. Only settable during space creation and enables direct logging. Must use HTTPS.",
+          "example": "https://example.com/logs",
+          "type": [
+            "string"
+          ]
+        },
+        "cidr": {
+          "description": "The RFC-1918 CIDR the Private Space will use. It must be a /16 in 10.0.0.0/8, 172.16.0.0/12 or 192.168.0.0/16",
+          "example": "172.20.20.30/16",
+          "default": "10.0.0.0/16",
+          "pattern": "^((?:10|172\\.(?:1[6-9]|2[0-9]|3[01])|192\\.168)\\..*.+\\/16)$",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "data_cidr": {
+          "description": "The RFC-1918 CIDR that the Private Space will use for the Heroku-managed peering connection that's automatically created when using Heroku Data add-ons. It must be between a /16 and a /20",
+          "example": "10.2.0.0/16",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "generation": {
+          "description": "Generation of the Heroku platform for this space",
+          "readOnly": true,
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "description": "unique identifier of the generation of the Heroku platform for this space",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "name": {
+              "description": "unique name of the generation of the Heroku platform for this space",
+              "example": "cedar",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "List existing spaces.",
+          "href": "/spaces",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/space"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Info for existing space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/space"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update an existing space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/space/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/space"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Delete an existing space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/space"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Create a new space.",
+          "href": "/spaces",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/space/definitions/name"
+              },
+              "team": {
+                "$ref": "#/definitions/team/definitions/name"
+              },
+              "region": {
+                "$ref": "#/definitions/region/definitions/identity"
+              },
+              "shield": {
+                "$ref": "#/definitions/space/definitions/shield"
+              },
+              "cidr": {
+                "$ref": "#/definitions/space/definitions/cidr"
+              },
+              "data_cidr": {
+                "$ref": "#/definitions/space/definitions/data_cidr"
+              },
+              "log_drain_url": {
+                "$ref": "#/definitions/space/definitions/log_drain_url"
+              },
+              "generation": {
+                "description": "unique name of the generation of the Heroku platform for this space",
+                "example": "cedar",
+                "readOnly": true,
+                "type": [
+                  "string"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "team"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/space"
+          },
+          "title": "Create"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/space/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/space/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/space/definitions/name"
+        },
+        "organization": {
+          "description": "organization that owns this space",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "team": {
+          "description": "team that owns this space",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "region": {
+          "description": "identity of space region",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/region/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/region/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "shield": {
+          "$ref": "#/definitions/space/definitions/shield"
+        },
+        "state": {
+          "$ref": "#/definitions/space/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/space/definitions/updated_at"
+        },
+        "cidr": {
+          "$ref": "#/definitions/space/definitions/cidr"
+        },
+        "data_cidr": {
+          "$ref": "#/definitions/space/definitions/data_cidr"
+        },
+        "generation": {
+          "$ref": "#/definitions/space/definitions/generation"
+        }
+      }
+    },
+    "stack": {
+      "description": "Stacks are the different application execution environments available in the Heroku platform.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Stack",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when stack was introduced",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "default": {
+          "description": "indicates this stack is the default for new apps",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of stack",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/stack/definitions/name"
+            },
+            {
+              "$ref": "#/definitions/stack/definitions/id"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of stack",
+          "example": "heroku-18",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "availability of this stack: beta, deprecated or public",
+          "example": "public",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when stack was last modified",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Stack info.",
+          "href": "/stacks/{(%23%2Fdefinitions%2Fstack%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/stack"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List available stacks.",
+          "href": "/stacks",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/stack"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List available app stacks for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/available-stacks",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/stack"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by App"
+        }
+      ],
+      "properties": {
+        "default": {
+          "$ref": "#/definitions/stack/definitions/default"
+        },
+        "created_at": {
+          "$ref": "#/definitions/stack/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/stack/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/stack/definitions/name"
+        },
+        "state": {
+          "$ref": "#/definitions/stack/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/stack/definitions/updated_at"
+        }
+      }
+    },
+    "team-add-on": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "title": "Heroku Platform API - Team Add-on",
+      "type": [
+        "object"
+      ],
+      "links": [
+        {
+          "description": "List add-ons used across all Team apps",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List For Team"
+        }
+      ]
+    },
+    "team-app-collaborator": {
+      "description": "A team collaborator represents an account that has been given access to a team app on Heroku.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "title": "Heroku Platform API - Team App Collaborator",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/collaborator/definitions/email"
+            }
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new collaborator on a team app. Use this endpoint instead of the `/apps/{app_id_or_name}/collaborator` endpoint when you want the collaborator to be granted [permissions] (https://devcenter.heroku.com/articles/org-users-access#roles-and-permissions) according to their role in the team.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/collaborators",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "permissions": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/team-app-permission/definitions/name"
+                },
+                "description": "An array of permissions to give to the collaborator."
+              },
+              "silent": {
+                "$ref": "#/definitions/collaborator/definitions/silent"
+              },
+              "user": {
+                "$ref": "#/definitions/account/definitions/identity"
+              }
+            },
+            "required": [
+              "user"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing collaborator from a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Fteam-app-collaborator%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for a collaborator on a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Fteam-app-collaborator%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update an existing collaborator from a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Fteam-app-collaborator%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "permissions": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/team-app-permission/definitions/name"
+                },
+                "description": "An array of permissions to give to the collaborator."
+              }
+            },
+            "required": [
+              "permissions"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "List collaborators on a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app-collaborator"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "app collaborator belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/collaborator/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/collaborator/definitions/id"
+        },
+        "permissions": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/team-app-permission"
+          },
+          "description": "array of permissions for the collaborator (only applicable if the app is on a team)"
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/collaborator/definitions/updated_at"
+        },
+        "user": {
+          "description": "identity of collaborated account",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "federated": {
+              "$ref": "#/definitions/account/definitions/federated"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "team-app-permission": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A team app permission is a behavior that is assigned to a user in a team app.",
+      "stability": "prototype",
+      "title": "Heroku Platform API - Team App Permission",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-app-permission/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "The name of the app permission.",
+          "example": "view",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "A description of what the app permission allows.",
+          "example": "Can manage config, deploy, run commands and restart the app.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Lists permissions available to teams.",
+          "href": "/teams/permissions",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app-permission"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/team-app-permission/definitions/name"
+        },
+        "description": {
+          "$ref": "#/definitions/team-app-permission/definitions/description"
+        }
+      }
+    },
+    "team-app": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A team app encapsulates the team specific functionality of Heroku apps.",
+      "stability": "development",
+      "title": "Heroku Platform API - Team App",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "locked": {
+          "default": false,
+          "description": "are other team members forbidden from joining this app.",
+          "example": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/app/definitions/name"
+        },
+        "internal_routing": {
+          "default": false,
+          "description": "describes whether a Private Spaces app is externally routable or not",
+          "example": false,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "joined": {
+          "default": false,
+          "description": "is the current member a collaborator on this app.",
+          "example": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "personal": {
+          "default": false,
+          "description": "force creation of the app in the user account even if a default team is set.",
+          "example": false,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new app in the specified team, in the default team if unspecified, or in personal account, if default team is not set.",
+          "href": "/teams/apps",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "locked": {
+                "$ref": "#/definitions/team-app/definitions/locked"
+              },
+              "name": {
+                "$ref": "#/definitions/app/definitions/name"
+              },
+              "team": {
+                "$ref": "#/definitions/team/definitions/name"
+              },
+              "personal": {
+                "$ref": "#/definitions/team-app/definitions/personal"
+              },
+              "region": {
+                "$ref": "#/definitions/region/definitions/name"
+              },
+              "space": {
+                "$ref": "#/definitions/space/definitions/name"
+              },
+              "stack": {
+                "$ref": "#/definitions/stack/definitions/name"
+              },
+              "internal_routing": {
+                "$ref": "#/definitions/team-app/definitions/internal_routing"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Info for a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-app"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Lock or unlock a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "locked": {
+                "$ref": "#/definitions/team-app/definitions/locked"
+              }
+            },
+            "required": [
+              "locked"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app"
+          },
+          "title": "Update Locked"
+        },
+        {
+          "description": "Transfer an existing team app to another Heroku account.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "owner": {
+                "$ref": "#/definitions/account/definitions/identity"
+              }
+            },
+            "required": [
+              "owner"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Transfer to Account"
+        },
+        {
+          "description": "Transfer an existing team app to another team.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "owner": {
+                "$ref": "#/definitions/team/definitions/name"
+              }
+            },
+            "required": [
+              "owner"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app"
+          },
+          "title": "Transfer to Team"
+        },
+        {
+          "description": "List team apps.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
+        }
+      ],
+      "properties": {
+        "archived_at": {
+          "$ref": "#/definitions/app/definitions/archived_at"
+        },
+        "buildpack_provided_description": {
+          "$ref": "#/definitions/app/definitions/buildpack_provided_description"
+        },
+        "build_stack": {
+          "description": "identity of the stack that will be used for new builds",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/app/definitions/created_at"
+        },
+        "git_url": {
+          "$ref": "#/definitions/app/definitions/git_url"
+        },
+        "id": {
+          "$ref": "#/definitions/app/definitions/id"
+        },
+        "internal_routing": {
+          "$ref": "#/definitions/team-app/definitions/internal_routing"
+        },
+        "joined": {
+          "$ref": "#/definitions/team-app/definitions/joined"
+        },
+        "locked": {
+          "$ref": "#/definitions/team-app/definitions/locked"
+        },
+        "maintenance": {
+          "$ref": "#/definitions/app/definitions/maintenance"
+        },
+        "name": {
+          "$ref": "#/definitions/app/definitions/name"
+        },
+        "team": {
+          "description": "team that owns this app",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "owner": {
+          "description": "identity of app owner",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "region": {
+          "description": "identity of app region",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/region/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/region/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "released_at": {
+          "$ref": "#/definitions/app/definitions/released_at"
+        },
+        "repo_size": {
+          "$ref": "#/definitions/app/definitions/repo_size"
+        },
+        "slug_size": {
+          "$ref": "#/definitions/app/definitions/slug_size"
+        },
+        "space": {
+          "description": "identity of space",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/space/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/space/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "stack": {
+          "description": "identity of app stack",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app/definitions/updated_at"
+        },
+        "web_url": {
+          "$ref": "#/definitions/app/definitions/web_url"
+        }
+      }
+    },
+    "team-daily-usage": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "Usage for an enterprise team at a daily resolution.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Daily Usage",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "addons": {
+          "description": "total add-on credits used",
+          "example": 250.0,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "app_usage_daily": {
+          "description": "Usage for an app at a daily resolution.",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "addons": {
+              "$ref": "#/definitions/team-daily-usage/definitions/addons"
+            },
+            "app_name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "data": {
+              "$ref": "#/definitions/team-daily-usage/definitions/data"
+            },
+            "dynos": {
+              "$ref": "#/definitions/team-daily-usage/definitions/dynos"
+            },
+            "partner": {
+              "$ref": "#/definitions/team-daily-usage/definitions/partner"
+            }
+          }
+        },
+        "data": {
+          "description": "total add-on credits used for first party add-ons",
+          "example": 34.89,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "date": {
+          "description": "date of the usage",
+          "example": "2019-01-01",
+          "format": "date",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "dynos": {
+          "description": "dynos used",
+          "example": 1.548,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "id": {
+          "description": "team identifier",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "name of the team",
+          "example": "ops",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "partner": {
+          "description": "total add-on credits used for third party add-ons",
+          "example": 12.34,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "space": {
+          "description": "space credits used",
+          "example": 1.548,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "start_date": {
+          "description": "range start date",
+          "example": "2019-01-25",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "end_date": {
+          "description": "range end date",
+          "example": "2019-02-25",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieves usage for an enterprise team for a range of days. Start and end dates can be specified as query parameters using the date format YYYY-MM-DD. The team identifier can be found from the [team list endpoint](https://devcenter.heroku.com/articles/platform-api-reference#team-list).\n",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fid)}/usage/daily",
+          "method": "GET",
+          "title": "Info",
+          "schema": {
+            "properties": {
+              "start": {
+                "$ref": "#/definitions/team-daily-usage/definitions/start_date"
+              },
+              "end": {
+                "$ref": "#/definitions/team-daily-usage/definitions/end_date"
+              }
+            },
+            "required": [
+              "start"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-daily-usage"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "addons": {
+          "$ref": "#/definitions/team-daily-usage/definitions/addons"
+        },
+        "apps": {
+          "description": "app usage in the team",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/team-daily-usage/definitions/app_usage_daily"
+          }
+        },
+        "data": {
+          "$ref": "#/definitions/team-daily-usage/definitions/data"
+        },
+        "date": {
+          "$ref": "#/definitions/team-daily-usage/definitions/date"
+        },
+        "dynos": {
+          "$ref": "#/definitions/team-daily-usage/definitions/dynos"
+        },
+        "id": {
+          "$ref": "#/definitions/team-daily-usage/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/team-daily-usage/definitions/name"
+        },
+        "partner": {
+          "$ref": "#/definitions/team-daily-usage/definitions/partner"
+        },
+        "space": {
+          "$ref": "#/definitions/team-daily-usage/definitions/space"
+        }
+      }
+    },
+    "team-delinquency": {
+      "description": "A Heroku team becomes delinquent due to non-payment. We [suspend and delete](https://help.heroku.com/EREVRILX/what-happens-if-i-have-unpaid-heroku-invoices) delinquent teams if their invoices remain unpaid.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Delinquency",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "scheduled_suspension_time": {
+          "description": "scheduled time of when we will suspend your team due to delinquency",
+          "example": "2024-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scheduled_deletion_time": {
+          "description": "scheduled time of when we will delete your team due to delinquency",
+          "example": "2024-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Team delinquency information.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/delinquency",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-delinquency"
+          },
+          "title": "Info"
+        }
+      ],
+      "properties": {
+        "scheduled_suspension_time": {
+          "$ref": "#/definitions/team-delinquency/definitions/scheduled_suspension_time"
+        },
+        "scheduled_deletion_time": {
+          "$ref": "#/definitions/team-delinquency/definitions/scheduled_deletion_time"
+        }
+      }
+    },
+    "team-feature": {
+      "description": "A team feature represents a feature enabled on a team account.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Feature",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when team feature was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of team feature",
+          "example": "Causes account to example.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "doc_url": {
+          "description": "documentation URL of team feature",
+          "example": "http://devcenter.heroku.com/articles/example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "enabled": {
+          "description": "whether or not team feature has been enabled",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of team feature",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-feature/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/team-feature/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of team feature",
+          "example": "name",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state of team feature",
+          "example": "public",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when team feature was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "display_name": {
+          "description": "user readable feature name",
+          "example": "My Feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "feedback_email": {
+          "description": "e-mail to send feedback about the feature",
+          "example": "feedback@heroku.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for an existing team feature.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Fteam-feature%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-feature"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing team features.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/features",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-feature"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/team-feature/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/team-feature/definitions/description"
+        },
+        "doc_url": {
+          "$ref": "#/definitions/team-feature/definitions/doc_url"
+        },
+        "enabled": {
+          "$ref": "#/definitions/team-feature/definitions/enabled"
+        },
+        "id": {
+          "$ref": "#/definitions/team-feature/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/team-feature/definitions/name"
+        },
+        "state": {
+          "$ref": "#/definitions/team-feature/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-feature/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/team-feature/definitions/display_name"
+        },
+        "feedback_email": {
+          "$ref": "#/definitions/team-feature/definitions/feedback_email"
+        }
+      }
+    },
+    "team-invitation": {
+      "description": "A team invitation represents an invite to a team.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Invitation",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when invitation was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-invitation/definitions/id"
+            }
+          ]
+        },
+        "id": {
+          "description": "unique identifier of an invitation",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "token": {
+          "description": "special token for invitation",
+          "example": "614ae25aa2d4802096cd7c18625b526c",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when invitation was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get a list of a team's Identity Providers",
+          "title": "List",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fname)}/invitations",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-invitation"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        },
+        {
+          "description": "Create Team Invitation",
+          "title": "Create",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invitations",
+          "method": "PUT",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              },
+              "role": {
+                "$ref": "#/definitions/team/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-invitation"
+          }
+        },
+        {
+          "description": "Revoke a team invitation.",
+          "title": "Revoke",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invitations/{(%23%2Fdefinitions%2Fteam-invitation%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-invitation"
+          }
+        },
+        {
+          "description": "Get an invitation by its token",
+          "title": "Get",
+          "href": "/teams/invitations/{(%23%2Fdefinitions%2Fteam-invitation%2Fdefinitions%2Ftoken)}",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "$ref": "#/definitions/team-invitation"
+          }
+        },
+        {
+          "description": "Accept Team Invitation",
+          "title": "Accept",
+          "href": "/teams/invitations/{(%23%2Fdefinitions%2Fteam-invitation%2Fdefinitions%2Ftoken)}/accept",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          }
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/team-invitation/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/team-invitation/definitions/id"
+        },
+        "invited_by": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "team": {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-invitation/definitions/updated_at"
+        },
+        "user": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "team-invoice": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A Team Invoice is an itemized bill of goods for a team which includes pricing and charges.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Invoice",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "addons_total": {
+          "description": "total add-ons charges in on this invoice",
+          "example": 25000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "database_total": {
+          "description": "total database charges on this invoice",
+          "example": 25000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "charges_total": {
+          "description": "total charges on this invoice",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "created_at": {
+          "description": "when invoice was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "credits_total": {
+          "description": "total credits on this invoice",
+          "example": 100000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "dyno_units": {
+          "description": "total amount of dyno units consumed across dyno types.",
+          "example": 1.92,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this invoice",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-invoice/definitions/number"
+            }
+          ]
+        },
+        "number": {
+          "description": "human readable invoice number",
+          "example": 9403943,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "payment_status": {
+          "description": "status of the invoice payment",
+          "example": "Paid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "platform_total": {
+          "description": "total platform charges on this invoice",
+          "example": 50000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "period_end": {
+          "description": "the ending date that the invoice covers",
+          "example": "01/31/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "period_start": {
+          "description": "the starting date that this invoice covers",
+          "example": "01/01/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "payment status for this invoice (pending, successful, failed)",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "total": {
+          "description": "combined total of charges and credits on this invoice",
+          "example": 100000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "updated_at": {
+          "description": "when invoice was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "weighted_dyno_hours": {
+          "description": "The total amount of hours consumed across dyno types.",
+          "example": 1488,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing invoice.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invoices/{(%23%2Fdefinitions%2Fteam-invoice%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-invoice"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing invoices.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invoices",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-invoice"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "addons_total": {
+          "$ref": "#/definitions/team-invoice/definitions/addons_total"
+        },
+        "database_total": {
+          "$ref": "#/definitions/team-invoice/definitions/database_total"
+        },
+        "charges_total": {
+          "$ref": "#/definitions/team-invoice/definitions/charges_total"
+        },
+        "created_at": {
+          "$ref": "#/definitions/team-invoice/definitions/created_at"
+        },
+        "credits_total": {
+          "$ref": "#/definitions/team-invoice/definitions/credits_total"
+        },
+        "dyno_units": {
+          "$ref": "#/definitions/team-invoice/definitions/dyno_units"
+        },
+        "id": {
+          "$ref": "#/definitions/team-invoice/definitions/id"
+        },
+        "number": {
+          "$ref": "#/definitions/team-invoice/definitions/number"
+        },
+        "payment_status": {
+          "$ref": "#/definitions/team-invoice/definitions/payment_status"
+        },
+        "period_end": {
+          "$ref": "#/definitions/team-invoice/definitions/period_end"
+        },
+        "period_start": {
+          "$ref": "#/definitions/team-invoice/definitions/period_start"
+        },
+        "platform_total": {
+          "$ref": "#/definitions/team-invoice/definitions/platform_total"
+        },
+        "state": {
+          "$ref": "#/definitions/team-invoice/definitions/state"
+        },
+        "total": {
+          "$ref": "#/definitions/team-invoice/definitions/total"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-invoice/definitions/updated_at"
+        },
+        "weighted_dyno_hours": {
+          "$ref": "#/definitions/team-invoice/definitions/weighted_dyno_hours"
+        }
+      }
+    },
+    "team-member": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A team member is an individual with access to a team.",
+      "stability": "development",
+      "additionalProperties": false,
+      "required": [
+        "created_at",
+        "email",
+        "federated",
+        "updated_at"
+      ],
+      "title": "Heroku Platform API - Team Member",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when the membership record was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "email": {
+          "description": "email address of the team member",
+          "example": "someone@example.org",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "federated": {
+          "description": "whether the user is federated and belongs to an Identity Provider",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of the team member",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-member/definitions/email"
+            },
+            {
+              "$ref": "#/definitions/team-member/definitions/id"
+            }
+          ]
+        },
+        "name": {
+          "description": "full name of the team member",
+          "example": "Tina Edmonds",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "team_role": {
+          "description": "role in the team",
+          "enum": [
+            "admin",
+            "viewer",
+            "member"
+          ],
+          "example": "admin",
+          "type": [
+            "string"
+          ]
+        },
+        "two_factor_authentication": {
+          "description": "whether the team member has two factor authentication enabled",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "updated_at": {
+          "description": "when the membership record was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new team member, or update their role.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "PUT",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/team-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/team-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/team-member/definitions/team_role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Create or Update"
+        },
+        {
+          "description": "Create a new team member.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/team-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/team-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/team-member/definitions/team_role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Update a team member.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/team-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/team-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/team-member/definitions/team_role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Remove a member from the team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Fteam-member%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "List members of the team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "GET",
+          "ranges": [
+            "email"
+          ],
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-member"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List the apps of a team member.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Fteam-member%2Fdefinitions%2Fidentity)}/apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Member"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/team-member/definitions/created_at"
+        },
+        "email": {
+          "$ref": "#/definitions/team-member/definitions/email"
+        },
+        "federated": {
+          "$ref": "#/definitions/team-member/definitions/federated"
+        },
+        "id": {
+          "$ref": "#/definitions/team-member/definitions/id"
+        },
+        "identity_provider": {
+          "description": "Identity Provider information the member is federated with",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/identity-provider/definitions/id"
+            },
+            "name": {
+              "description": "name of the identity provider",
+              "example": "acme",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "redacted": {
+              "description": "whether the identity_provider information is redacted or not",
+              "example": false,
+              "readOnly": true,
+              "type": [
+                "boolean"
+              ]
+            },
+            "owner": {
+              "$ref": "#/definitions/identity-provider/definitions/owner"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "two_factor_authentication": {
+          "$ref": "#/definitions/team-member/definitions/two_factor_authentication"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-member/definitions/updated_at"
+        },
+        "user": {
+          "description": "user information for the membership",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "team-monthly-usage": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "Usage for an enterprise team at a monthly resolution.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Monthly Usage",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "addons": {
+          "description": "total add-on credits used",
+          "example": 250.0,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "app_usage_monthly": {
+          "description": "Usage for an app at a monthly resolution.",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "addons": {
+              "$ref": "#/definitions/team-monthly-usage/definitions/addons"
+            },
+            "app_name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "data": {
+              "$ref": "#/definitions/team-monthly-usage/definitions/data"
+            },
+            "dynos": {
+              "$ref": "#/definitions/team-monthly-usage/definitions/dynos"
+            },
+            "partner": {
+              "$ref": "#/definitions/team-monthly-usage/definitions/partner"
+            }
+          }
+        },
+        "connect": {
+          "description": "max connect rows synced",
+          "example": 15000,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "data": {
+          "description": "total add-on credits used for first party add-ons",
+          "example": 34.89,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "dynos": {
+          "description": "dynos used",
+          "example": 1.548,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "id": {
+          "description": "team identifier",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "month": {
+          "description": "year and month of the usage",
+          "example": "2019-01",
+          "pattern": "^[0-9]{4}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "name of the team",
+          "example": "ops",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "partner": {
+          "description": "total add-on credits used for third party add-ons",
+          "example": 12.34,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "space": {
+          "description": "space credits used",
+          "example": 1.548,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "start_date": {
+          "description": "range start date",
+          "example": "2019-01",
+          "pattern": "^[0-9]{4}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "end_date": {
+          "description": "range end date",
+          "example": "2019-02",
+          "pattern": "^[0-9]{4}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieves usage for an enterprise team for a range of months. Start and end dates can be specified as query parameters using the date, YYYY-MM. If no end date is specified, one month of usage is returned. The team identifier can be found from the [team list endpoint](https://devcenter.heroku.com/articles/platform-api-reference#team-list).\n",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fid)}/usage/monthly",
+          "method": "GET",
+          "title": "Info",
+          "schema": {
+            "properties": {
+              "start": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/start_date"
+              },
+              "end": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/end_date"
+              }
+            },
+            "required": [
+              "start"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-monthly-usage"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "addons": {
+          "$ref": "#/definitions/team-monthly-usage/definitions/addons"
+        },
+        "apps": {
+          "description": "app usage in the team",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/team-monthly-usage/definitions/app_usage_monthly"
+          }
+        },
+        "connect": {
+          "$ref": "#/definitions/team-monthly-usage/definitions/connect"
+        },
+        "data": {
+          "$ref": "#/definitions/team-monthly-usage/definitions/data"
+        },
+        "dynos": {
+          "$ref": "#/definitions/team-monthly-usage/definitions/dynos"
+        },
+        "id": {
+          "$ref": "#/definitions/team-monthly-usage/definitions/id"
+        },
+        "month": {
+          "$ref": "#/definitions/team-monthly-usage/definitions/month"
+        },
+        "name": {
+          "$ref": "#/definitions/team-monthly-usage/definitions/name"
+        },
+        "partner": {
+          "$ref": "#/definitions/team-monthly-usage/definitions/partner"
+        },
+        "space": {
+          "$ref": "#/definitions/team-monthly-usage/definitions/space"
+        }
+      }
+    },
+    "team-preferences": {
+      "description": "Tracks a Team's Preferences",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Preferences",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "default-permission": {
+          "description": "The default permission used when adding new members to the team",
+          "example": "member",
+          "readOnly": false,
+          "enum": [
+            "admin",
+            "member",
+            "viewer",
+            null
+          ],
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/team/definitions/identity"
+        },
+        "addons-controls": {
+          "description": "Whether add-on service rules should be applied to add-on installations",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieve Team Preferences",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-preferences"
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update Team Preferences",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "addons-controls": {
+                "$ref": "#/definitions/team-preferences/definitions/addons-controls"
+              }
+            }
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-preferences"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "default-permission": {
+          "$ref": "#/definitions/team-preferences/definitions/default-permission"
+        },
+        "addons-controls": {
+          "$ref": "#/definitions/team-preferences/definitions/addons-controls"
+        }
+      }
+    },
+    "team-space": {
+      "description": "A space is an isolated, highly available, secure app execution environment.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Space",
+      "type": [
+        "object"
+      ],
+      "links": [
+        {
+          "description": "List spaces owned by the team",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/spaces",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/space"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ]
+    },
+    "team": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "Teams allow you to manage access to a shared group of applications and other resources.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when the team was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "credit_card_collections": {
+          "description": "whether charges incurred by the team are paid by credit card.",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "default": {
+          "description": "whether to use this team when none is specified",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "enterprise_account": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/enterprise-account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/enterprise-account/definitions/name"
+            }
+          }
+        },
+        "id": {
+          "description": "unique identifier of team",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team/definitions/name"
+            },
+            {
+              "$ref": "#/definitions/team/definitions/id"
+            }
+          ]
+        },
+        "identity_provider": {
+          "description": "Identity Provider associated with the Team",
+          "strictProperties": true,
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/identity-provider/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/identity-provider/definitions/name"
+            },
+            "owner": {
+              "$ref": "#/definitions/identity-provider/definitions/owner"
+            }
+          }
+        },
+        "device_data": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Device data string generated by the client",
+          "example": "VGhpcyBpcyBhIGdvb2QgZGF5IHRvIGRpZQ=="
+        },
+        "nonce": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Nonce generated by Braintree hosted fields form",
+          "example": "VGhpcyBpcyBhIGdvb2QgZGF5IHRvIGRpZQ=="
+        },
+        "address_1": {
+          "type": [
+            "string"
+          ],
+          "description": "street address line 1",
+          "example": "40 Hickory Lane"
+        },
+        "address_2": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "street address line 2",
+          "example": "Suite 103"
+        },
+        "card_number": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "encrypted card number of payment method",
+          "example": "encrypted-card-number"
+        },
+        "city": {
+          "type": [
+            "string"
+          ],
+          "description": "city",
+          "example": "San Francisco"
+        },
+        "country": {
+          "type": [
+            "string"
+          ],
+          "description": "country",
+          "example": "US"
+        },
+        "cvv": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "card verification value",
+          "example": "123"
+        },
+        "expiration_month": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "expiration month",
+          "example": "11"
+        },
+        "expiration_year": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "expiration year",
+          "example": "2014"
+        },
+        "first_name": {
+          "type": [
+            "string"
+          ],
+          "description": "the first name for payment method",
+          "example": "Jason"
+        },
+        "last_name": {
+          "type": [
+            "string"
+          ],
+          "description": "the last name for payment method",
+          "example": "Walker"
+        },
+        "other": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "metadata",
+          "example": "Additional information for payment method"
+        },
+        "postal_code": {
+          "type": [
+            "string"
+          ],
+          "description": "postal code",
+          "example": "90210"
+        },
+        "state": {
+          "type": [
+            "string"
+          ],
+          "description": "state",
+          "example": "CA"
+        },
+        "membership_limit": {
+          "description": "upper limit of members allowed in a team.",
+          "example": 25,
+          "readOnly": true,
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "unique name of team",
+          "example": "example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "provisioned_licenses": {
+          "description": "whether the team is provisioned licenses by salesforce.",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "role": {
+          "description": "role in the team",
+          "enum": [
+            "admin",
+            "collaborator",
+            "member",
+            "owner",
+            null
+          ],
+          "example": "admin",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "type": {
+          "description": "type of team.",
+          "example": "team",
+          "enum": [
+            "enterprise",
+            "team"
+          ],
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the team was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List teams in which you are a member.",
+          "href": "/teams",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Info for a team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update team properties.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "default": {
+                "$ref": "#/definitions/team/definitions/default"
+              },
+              "name": {
+                "$ref": "#/definitions/team/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Create a new team.",
+          "href": "/teams",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/team/definitions/name"
+              },
+              "address_1": {
+                "$ref": "#/definitions/team/definitions/address_1"
+              },
+              "address_2": {
+                "$ref": "#/definitions/team/definitions/address_2"
+              },
+              "card_number": {
+                "$ref": "#/definitions/team/definitions/card_number"
+              },
+              "city": {
+                "$ref": "#/definitions/team/definitions/city"
+              },
+              "country": {
+                "$ref": "#/definitions/team/definitions/country"
+              },
+              "cvv": {
+                "$ref": "#/definitions/team/definitions/cvv"
+              },
+              "expiration_month": {
+                "$ref": "#/definitions/team/definitions/expiration_month"
+              },
+              "expiration_year": {
+                "$ref": "#/definitions/team/definitions/expiration_year"
+              },
+              "first_name": {
+                "$ref": "#/definitions/team/definitions/first_name"
+              },
+              "last_name": {
+                "$ref": "#/definitions/team/definitions/last_name"
+              },
+              "other": {
+                "$ref": "#/definitions/team/definitions/other"
+              },
+              "postal_code": {
+                "$ref": "#/definitions/team/definitions/postal_code"
+              },
+              "state": {
+                "$ref": "#/definitions/team/definitions/state"
+              },
+              "nonce": {
+                "$ref": "#/definitions/team/definitions/nonce"
+              },
+              "device_data": {
+                "$ref": "#/definitions/team/definitions/device_data"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/team"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "List teams for an enterprise account.",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}/teams",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by Enterprise Account"
+        },
+        {
+          "description": "Create a team in an enterprise account.",
+          "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}/teams",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/team/definitions/name"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team"
+          },
+          "title": "Create in Enterprise Account"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/team/definitions/id"
+        },
+        "created_at": {
+          "$ref": "#/definitions/team/definitions/created_at"
+        },
+        "credit_card_collections": {
+          "$ref": "#/definitions/team/definitions/credit_card_collections"
+        },
+        "default": {
+          "$ref": "#/definitions/team/definitions/default"
+        },
+        "enterprise_account": {
+          "$ref": "#/definitions/team/definitions/enterprise_account"
+        },
+        "identity_provider": {
+          "$ref": "#/definitions/team/definitions/identity_provider"
+        },
+        "membership_limit": {
+          "$ref": "#/definitions/team/definitions/membership_limit"
+        },
+        "name": {
+          "$ref": "#/definitions/team/definitions/name"
+        },
+        "provisioned_licenses": {
+          "$ref": "#/definitions/team/definitions/provisioned_licenses"
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "type": {
+          "$ref": "#/definitions/team/definitions/type"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team/definitions/updated_at"
+        }
+      }
+    },
+    "telemetry-drain": {
+      "description": "A telemetry drain forwards OpenTelemetry traces, metrics, and logs to your own consumer. For Fir-generation apps only.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Telemetry Drain",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of telemetry drain",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/telemetry-drain/definitions/id"
+            }
+          ]
+        },
+        "created_at": {
+          "description": "when the telemetry drain was created",
+          "example": "2024-12-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when telemetry drain was last updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "signal": {
+          "description": "OpenTelemetry signal to be sent to the telemetry drain",
+          "readOnly": true,
+          "example": "traces",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "traces",
+            "metrics",
+            "logs"
+          ]
+        },
+        "signals": {
+          "description": "OpenTelemetry signals to send to telemetry drain",
+          "example": [
+            "traces",
+            "metrics"
+          ],
+          "readOnly": false,
+          "minItems": 1,
+          "uniqueItems": true,
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/telemetry-drain/definitions/signal"
+          }
+        },
+        "exporter_type": {
+          "description": "the transport type to be used for your OpenTelemetry consumer",
+          "readOnly": true,
+          "example": "otlphttp",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "otlphttp",
+            "otlp"
+          ]
+        },
+        "exporter_endpoint": {
+          "description": "URI of your OpenTelemetry consumer",
+          "readOnly": false,
+          "example": "https://api.otelproduct.example/consumer",
+          "maxLength": 1000,
+          "type": [
+            "string"
+          ]
+        },
+        "exporter_headers": {
+          "description": "JSON headers to send to your OpenTelemetry consumer",
+          "readOnly": false,
+          "example": {
+            "API-Key": "example_api_key_012345",
+            "Environment": "production"
+          },
+          "default": {},
+          "additionalProperties": false,
+          "maxItems": 20,
+          "patternProperties": {
+            "^[A-Za-z0-9\\-_]{1,100}$": {
+              "maxLength": 1000,
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "exporter": {
+          "description": "OpenTelemetry exporter configuration",
+          "readOnly": false,
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "$ref": "#/definitions/telemetry-drain/definitions/exporter_type"
+            },
+            "endpoint": {
+              "$ref": "#/definitions/telemetry-drain/definitions/exporter_endpoint"
+            },
+            "headers": {
+              "$ref": "#/definitions/telemetry-drain/definitions/exporter_headers"
+            }
+          },
+          "required": [
+            "type",
+            "endpoint"
+          ],
+          "type": [
+            "object"
+          ]
+        },
+        "owner": {
+          "description": "entity that owns this telemetry drain",
+          "properties": {
+            "id": {
+              "description": "unique identifier of owner",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "type": {
+              "description": "type of owner",
+              "enum": [
+                "app",
+                "space"
+              ],
+              "example": "app",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "readOnly": false,
+          "required": [
+            "id",
+            "type"
+          ],
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a telemetry drain.",
+          "href": "/telemetry-drains",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "additionalProperties": false,
+            "properties": {
+              "owner": {
+                "$ref": "#/definitions/telemetry-drain/definitions/owner"
+              },
+              "signals": {
+                "$ref": "#/definitions/telemetry-drain/definitions/signals"
+              },
+              "exporter": {
+                "$ref": "#/definitions/telemetry-drain/definitions/exporter"
+              }
+            },
+            "required": [
+              "owner",
+              "signals",
+              "exporter"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/telemetry-drain"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "List telemetry drains for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/telemetry-drains",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/telemetry-drain"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by App"
+        },
+        {
+          "description": "List telemetry drains for a space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/telemetry-drains",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/telemetry-drain"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by Space"
+        },
+        {
+          "description": "Update a telemetry drain.",
+          "href": "/telemetry-drains/{(%23%2Fdefinitions%2Ftelemetry-drain%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "additionalProperties": false,
+            "properties": {
+              "signals": {
+                "$ref": "#/definitions/telemetry-drain/definitions/signals"
+              },
+              "exporter": {
+                "$ref": "#/definitions/telemetry-drain/definitions/exporter"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/telemetry-drain"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Delete a telemetry drain.",
+          "href": "/telemetry-drains/{(%23%2Fdefinitions%2Ftelemetry-drain%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/telemetry-drain"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for a telemetry drain.",
+          "href": "/telemetry-drains/{(%23%2Fdefinitions%2Ftelemetry-drain%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/telemetry-drain"
+          },
+          "title": "Info"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/telemetry-drain/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/telemetry-drain/definitions/id"
+        },
+        "owner": {
+          "$ref": "#/definitions/telemetry-drain/definitions/owner"
+        },
+        "signals": {
+          "$ref": "#/definitions/telemetry-drain/definitions/signals"
+        },
+        "exporter": {
+          "$ref": "#/definitions/telemetry-drain/definitions/exporter"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/telemetry-drain/definitions/updated_at"
+        }
+      }
+    },
+    "test-case": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Test Case",
+      "description": "A single test case belonging to a test run",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of a test case",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of the test case",
+          "type": [
+            "string"
+          ]
+        },
+        "diagnostic": {
+          "description": "meta information about the test case",
+          "type": [
+            "string"
+          ]
+        },
+        "directive": {
+          "description": "special note about the test case e.g. skipped, todo",
+          "type": [
+            "string"
+          ]
+        },
+        "passed": {
+          "description": "whether the test case was successful",
+          "type": [
+            "boolean"
+          ]
+        },
+        "number": {
+          "description": "the test number",
+          "type": [
+            "integer"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/test-case/definitions/id"
+            }
+          ]
+        },
+        "created_at": {
+          "description": "when test case was created",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when test case was updated",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List test cases",
+          "href": "/test-runs/{(%23%2Fdefinitions%2Ftest-run%2Fdefinitions%2Fid)}/test-cases",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/test-case"
+            }
+          },
+          "type": [
+            "array"
+          ],
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/test-case/definitions/id"
+        },
+        "created_at": {
+          "$ref": "#/definitions/test-case/definitions/created_at"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/test-case/definitions/updated_at"
+        },
+        "description": {
+          "$ref": "#/definitions/test-case/definitions/description"
+        },
+        "diagnostic": {
+          "$ref": "#/definitions/test-case/definitions/diagnostic"
+        },
+        "directive": {
+          "$ref": "#/definitions/test-case/definitions/directive"
+        },
+        "passed": {
+          "$ref": "#/definitions/test-case/definitions/passed"
+        },
+        "number": {
+          "$ref": "#/definitions/test-case/definitions/number"
+        },
+        "test_node": {
+          "description": "the test node which executed this test case",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/test-node/definitions/identity"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "test_run": {
+          "description": "the test run which owns this test case",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/test-run/definitions/identity"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "test-node": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Test Node",
+      "description": "A single test node belonging to a test run",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of a test node",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "attach_url": {
+          "description": "a URL to stream output from for debug runs or null for non-debug runs",
+          "example": "rendezvous://rendezvous.runtime.heroku.com:5000/{rendezvous-id}",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "created_at": {
+          "description": "when test node was created",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "error_status": {
+          "description": "the status of the test run when the error occured",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "exit_code": {
+          "description": "the exit code of the test script",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/test-node/definitions/id"
+            }
+          ]
+        },
+        "index": {
+          "description": "The index of the test node",
+          "type": [
+            "integer"
+          ]
+        },
+        "message": {
+          "description": "human friendly message indicating reason for an error",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_stream_url": {
+          "description": "the streaming output for the test node",
+          "example": "https://example.com/output.log",
+          "type": [
+            "string"
+          ]
+        },
+        "setup_stream_url": {
+          "description": "the streaming test setup output for the test node",
+          "example": "https://example.com/test-setup.log",
+          "type": [
+            "string"
+          ]
+        },
+        "status": {
+          "description": "current state of the test run",
+          "enum": [
+            "pending",
+            "cancelled",
+            "creating",
+            "building",
+            "running",
+            "succeeded",
+            "failed",
+            "errored",
+            "debugging"
+          ],
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when test node was updated",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List test nodes",
+          "href": "/test-runs/{(%23%2Fdefinitions%2Ftest-run%2Fdefinitions%2Fidentity)}/test-nodes",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/test-node"
+            }
+          },
+          "type": [
+            "array"
+          ],
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/test-node/definitions/created_at"
+        },
+        "dyno": {
+          "description": "the dyno which belongs to this test node",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/dyno/definitions/identity"
+            },
+            "attach_url": {
+              "$ref": "#/definitions/test-node/definitions/attach_url"
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "error_status": {
+          "$ref": "#/definitions/test-node/definitions/error_status"
+        },
+        "exit_code": {
+          "$ref": "#/definitions/test-node/definitions/exit_code"
+        },
+        "id": {
+          "$ref": "#/definitions/test-node/definitions/identity"
+        },
+        "index": {
+          "$ref": "#/definitions/test-node/definitions/index"
+        },
+        "message": {
+          "$ref": "#/definitions/test-node/definitions/message"
+        },
+        "output_stream_url": {
+          "$ref": "#/definitions/test-node/definitions/output_stream_url"
+        },
+        "pipeline": {
+          "description": "the pipeline which owns this test node",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/identity"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "setup_stream_url": {
+          "$ref": "#/definitions/test-node/definitions/setup_stream_url"
+        },
+        "status": {
+          "$ref": "#/definitions/test-node/definitions/status"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/test-node/definitions/updated_at"
+        },
+        "test_run": {
+          "description": "the test run which owns this test node",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/test-run/definitions/identity"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "test-run": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Test Run",
+      "description": "An execution or trial of one or more tests",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "actor_email": {
+          "description": "the email of the actor triggering the test run",
+          "type": [
+            "string"
+          ],
+          "format": "email"
+        },
+        "clear_cache": {
+          "description": "whether the test was run with an empty cache",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "commit_branch": {
+          "description": "the branch of the repository that the test run concerns",
+          "type": [
+            "string"
+          ]
+        },
+        "commit_message": {
+          "description": "the message for the commit under test",
+          "type": [
+            "string"
+          ]
+        },
+        "commit_sha": {
+          "description": "the SHA hash of the commit under test",
+          "type": [
+            "string"
+          ]
+        },
+        "debug": {
+          "description": "whether the test run was started for interactive debugging",
+          "type": [
+            "boolean"
+          ]
+        },
+        "app_setup": {
+          "description": "the app setup for the test run",
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of a test run",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/test-run/definitions/id"
+            }
+          ]
+        },
+        "created_at": {
+          "description": "when test run was created",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "message": {
+          "description": "human friendly message indicating reason for an error",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "number": {
+          "description": "the auto incrementing test run number",
+          "type": [
+            "integer"
+          ]
+        },
+        "source_blob_url": {
+          "description": "The download location for the source code to be tested",
+          "type": [
+            "string"
+          ]
+        },
+        "status": {
+          "description": "current state of the test run",
+          "enum": [
+            "pending",
+            "cancelled",
+            "creating",
+            "building",
+            "running",
+            "succeeded",
+            "failed",
+            "errored",
+            "debugging"
+          ],
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when test-run was updated",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "warning_message": {
+          "description": "human friently warning emitted during the test run",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new test-run.",
+          "href": "/test-runs",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "commit_branch": {
+                "$ref": "#/definitions/test-run/definitions/commit_branch"
+              },
+              "commit_message": {
+                "$ref": "#/definitions/test-run/definitions/commit_message"
+              },
+              "commit_sha": {
+                "$ref": "#/definitions/test-run/definitions/commit_sha"
+              },
+              "debug": {
+                "$ref": "#/definitions/test-run/definitions/debug"
+              },
+              "organization": {
+                "$ref": "#/definitions/team/definitions/identity"
+              },
+              "pipeline": {
+                "$ref": "#/definitions/pipeline/definitions/identity"
+              },
+              "source_blob_url": {
+                "$ref": "#/definitions/test-run/definitions/source_blob_url"
+              }
+            },
+            "required": [
+              "commit_branch",
+              "commit_message",
+              "commit_sha",
+              "pipeline",
+              "source_blob_url"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Info for existing test-run.",
+          "href": "/test-runs/{(%23%2Fdefinitions%2Ftest-run%2Fdefinitions%2Fid)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "List existing test-runs for a pipeline.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/test-runs",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/test-run"
+            }
+          },
+          "type": [
+            "array"
+          ],
+          "title": "List"
+        },
+        {
+          "description": "Info for existing test-run by Pipeline",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/test-runs/{(%23%2Fdefinitions%2Ftest-run%2Fdefinitions%2Fnumber)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info By Pipeline"
+        },
+        {
+          "description": "Update a test-run's status.",
+          "href": "/test-runs/{(%23%2Fdefinitions%2Ftest-run%2Fdefinitions%2Fnumber)}",
+          "method": "PATCH",
+          "rel": "self",
+          "title": "Update",
+          "schema": {
+            "properties": {
+              "status": {
+                "$ref": "#/definitions/test-run/definitions/status"
+              },
+              "message": {
+                "$ref": "#/definitions/test-run/definitions/message"
+              }
+            },
+            "required": [
+              "status",
+              "message"
+            ],
+            "type": [
+              "object"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "actor_email": {
+          "$ref": "#/definitions/test-run/definitions/actor_email"
+        },
+        "clear_cache": {
+          "$ref": "#/definitions/test-run/definitions/clear_cache"
+        },
+        "commit_branch": {
+          "$ref": "#/definitions/test-run/definitions/commit_branch"
+        },
+        "commit_message": {
+          "$ref": "#/definitions/test-run/definitions/commit_message"
+        },
+        "commit_sha": {
+          "$ref": "#/definitions/test-run/definitions/commit_sha"
+        },
+        "debug": {
+          "$ref": "#/definitions/test-run/definitions/debug"
+        },
+        "app_setup": {
+          "$ref": "#/definitions/test-run/definitions/app_setup"
+        },
+        "created_at": {
+          "$ref": "#/definitions/test-run/definitions/created_at"
+        },
+        "dyno": {
+          "description": "the type of dynos used for this test-run",
+          "properties": {
+            "size": {
+              "$ref": "#/definitions/dyno/definitions/size"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/test-run/definitions/id"
+        },
+        "message": {
+          "$ref": "#/definitions/test-run/definitions/message"
+        },
+        "number": {
+          "$ref": "#/definitions/test-run/definitions/number"
+        },
+        "organization": {
+          "description": "the team that owns this test-run",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "pipeline": {
+          "description": "the pipeline which owns this test-run",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/identity"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/test-run/definitions/status"
+        },
+        "source_blob_url": {
+          "$ref": "#/definitions/test-run/definitions/source_blob_url"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/test-run/definitions/updated_at"
+        },
+        "user": {
+          "$ref": "#/definitions/account"
+        },
+        "warning_message": {
+          "$ref": "#/definitions/test-run/definitions/warning_message"
+        }
+      }
+    },
+    "user-preferences": {
+      "description": "Tracks a user's preferences and message dismissals",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - User Preferences",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/user-preferences/definitions/self"
+            }
+          ]
+        },
+        "self": {
+          "description": "Implicit reference to currently authorized user",
+          "enum": [
+            "~"
+          ],
+          "example": "~",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "timezone": {
+          "description": "User's default timezone",
+          "example": "UTC",
+          "readOnly": false,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "default-organization": {
+          "description": "User's default team",
+          "example": "sushi-inc",
+          "readOnly": false,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dismissed-github-banner": {
+          "description": "Whether the user has dismissed the GitHub link banner",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-getting-started": {
+          "description": "Whether the user has dismissed the getting started banner",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-org-access-controls": {
+          "description": "Whether the user has dismissed the Organization Access Controls banner",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-org-wizard-notification": {
+          "description": "Whether the user has dismissed the Organization Wizard",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-pipelines-banner": {
+          "description": "Whether the user has dismissed the Pipelines banner",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-pipelines-github-banner": {
+          "description": "Whether the user has dismissed the GitHub banner on a pipeline overview",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-pipelines-github-banners": {
+          "description": "Which pipeline uuids the user has dismissed the GitHub banner for",
+          "example": [
+            "96c68759-f310-4910-9867-e0b062064098"
+          ],
+          "readOnly": false,
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/pipeline/definitions/id"
+          }
+        },
+        "dismissed-sms-banner": {
+          "description": "Whether the user has dismissed the 2FA SMS banner",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieve User Preferences",
+          "href": "/users/{(%23%2Fdefinitions%2Fuser-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/user-preferences"
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update User Preferences",
+          "href": "/users/{(%23%2Fdefinitions%2Fuser-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "timezone": {
+                "$ref": "#/definitions/user-preferences/definitions/timezone"
+              },
+              "default-organization": {
+                "$ref": "#/definitions/user-preferences/definitions/default-organization"
+              },
+              "dismissed-github-banner": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-github-banner"
+              },
+              "dismissed-getting-started": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-getting-started"
+              },
+              "dismissed-org-access-controls": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-org-access-controls"
+              },
+              "dismissed-org-wizard-notification": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-org-wizard-notification"
+              },
+              "dismissed-pipelines-banner": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-banner"
+              },
+              "dismissed-pipelines-github-banner": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-github-banner"
+              },
+              "dismissed-pipelines-github-banners": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-github-banners"
+              },
+              "dismissed-sms-banner": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-sms-banner"
+              }
+            }
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/user-preferences"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "timezone": {
+          "$ref": "#/definitions/user-preferences/definitions/timezone"
+        },
+        "default-organization": {
+          "$ref": "#/definitions/user-preferences/definitions/default-organization"
+        },
+        "dismissed-github-banner": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-github-banner"
+        },
+        "dismissed-getting-started": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-getting-started"
+        },
+        "dismissed-org-access-controls": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-org-access-controls"
+        },
+        "dismissed-org-wizard-notification": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-org-wizard-notification"
+        },
+        "dismissed-pipelines-banner": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-banner"
+        },
+        "dismissed-pipelines-github-banner": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-github-banner"
+        },
+        "dismissed-pipelines-github-banners": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-github-banners"
+        },
+        "dismissed-sms-banner": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-sms-banner"
+        }
+      }
+    },
+    "vpn-connection": {
+      "description": "[VPN](https://devcenter.heroku.com/articles/private-space-vpn-connection) provides a way to connect your Private Spaces to your network via VPN.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Private Spaces VPN",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "name": {
+          "description": "VPN Name",
+          "example": "office",
+          "type": [
+            "string"
+          ]
+        },
+        "public_ip": {
+          "description": "Public IP of VPN customer gateway",
+          "example": "35.161.69.30",
+          "type": [
+            "string"
+          ]
+        },
+        "routable_cidrs": {
+          "description": "Routable CIDRs of VPN",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "example": "172.16.0.0/16",
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "id": {
+          "description": "VPN ID",
+          "example": "123456789012",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/vpn-connection/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/vpn-connection/definitions/name"
+            }
+          ]
+        },
+        "space_cidr_block": {
+          "description": "CIDR Block of the Private Space",
+          "example": "10.0.0.0/16",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "ike_version": {
+          "description": "IKE Version",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "tunnel": {
+          "description": "Tunnel info",
+          "readOnly": true,
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "last_status_change": {
+              "description": "Timestamp of last status changed",
+              "example": "2016-10-25T22:09:05Z",
+              "type": [
+                "string"
+              ]
+            },
+            "ip": {
+              "description": "Public IP address for the tunnel",
+              "example": "52.44.146.197",
+              "type": [
+                "string"
+              ]
+            },
+            "customer_ip": {
+              "description": "Public IP address for the customer side of the tunnel",
+              "example": "52.44.146.197",
+              "type": [
+                "string"
+              ]
+            },
+            "pre_shared_key": {
+              "description": "Pre-shared key",
+              "example": "secret",
+              "type": [
+                "string"
+              ]
+            },
+            "status": {
+              "description": "Status of the tunnel",
+              "enum": [
+                "UP",
+                "DOWN"
+              ],
+              "example": "UP",
+              "type": [
+                "string"
+              ]
+            },
+            "status_message": {
+              "description": "Details of the status",
+              "example": "status message",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "status": {
+          "description": "Status of the VPN",
+          "enum": [
+            "pending",
+            "provisioning",
+            "active",
+            "deprovisioning",
+            "failed"
+          ],
+          "example": "active",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "status_message": {
+          "description": "Details of the status",
+          "example": "supplied CIDR block already in use",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/vpn-connection/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/vpn-connection/definitions/name"
+        },
+        "public_ip": {
+          "$ref": "#/definitions/vpn-connection/definitions/public_ip"
+        },
+        "routable_cidrs": {
+          "$ref": "#/definitions/vpn-connection/definitions/routable_cidrs"
+        },
+        "space_cidr_block": {
+          "$ref": "#/definitions/vpn-connection/definitions/space_cidr_block"
+        },
+        "tunnels": {
+          "items": {
+            "$ref": "#/definitions/vpn-connection/definitions/tunnel"
+          },
+          "type": [
+            "array"
+          ]
+        },
+        "ike_version": {
+          "$ref": "#/definitions/vpn-connection/definitions/ike_version"
+        },
+        "status": {
+          "$ref": "#/definitions/vpn-connection/definitions/status"
+        },
+        "status_message": {
+          "$ref": "#/definitions/vpn-connection/definitions/status_message"
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new VPN connection in a private space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/vpn-connections",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/vpn-connection/definitions/name"
+              },
+              "public_ip": {
+                "$ref": "#/definitions/vpn-connection/definitions/public_ip"
+              },
+              "routable_cidrs": {
+                "$ref": "#/definitions/vpn-connection/definitions/routable_cidrs"
+              }
+            },
+            "required": [
+              "name",
+              "public_ip",
+              "routable_cidrs"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/vpn-connection"
+          },
+          "method": "POST",
+          "title": "Create"
+        },
+        {
+          "description": "Destroy existing VPN Connection",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/vpn-connections/{(%23%2Fdefinitions%2Fvpn-connection%2Fdefinitions%2Fidentity)}",
+          "rel": "empty",
+          "method": "DELETE",
+          "targetSchema": {
+            "$ref": "#/definitions/vpn-connection"
+          },
+          "title": "Destroy"
+        },
+        {
+          "description": "List VPN connections for a space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/vpn-connections",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/vpn-connection"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Info for an existing vpn-connection.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/vpn-connections/{(%23%2Fdefinitions%2Fvpn-connection%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/vpn-connection"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update a VPN connection in a private space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/vpn-connections/{(%23%2Fdefinitions%2Fvpn-connection%2Fdefinitions%2Fidentity)}",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "routable_cidrs": {
+                "$ref": "#/definitions/vpn-connection/definitions/routable_cidrs"
+              }
+            },
+            "required": [
+              "routable_cidrs"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/vpn-connection"
+          },
+          "method": "PATCH",
+          "title": "Update"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "account-delinquency": {
+      "$ref": "#/definitions/account-delinquency"
+    },
+    "account-feature": {
+      "$ref": "#/definitions/account-feature"
+    },
+    "account": {
+      "$ref": "#/definitions/account"
+    },
+    "add-on-action": {
+      "$ref": "#/definitions/add-on-action"
+    },
+    "add-on-attachment": {
+      "$ref": "#/definitions/add-on-attachment"
+    },
+    "add-on-config": {
+      "$ref": "#/definitions/add-on-config"
+    },
+    "add-on-plan-action": {
+      "$ref": "#/definitions/add-on-plan-action"
+    },
+    "add-on-region-capability": {
+      "$ref": "#/definitions/add-on-region-capability"
+    },
+    "add-on-service": {
+      "$ref": "#/definitions/add-on-service"
+    },
+    "add-on-webhook-delivery": {
+      "$ref": "#/definitions/add-on-webhook-delivery"
+    },
+    "add-on-webhook-event": {
+      "$ref": "#/definitions/add-on-webhook-event"
+    },
+    "add-on-webhook": {
+      "$ref": "#/definitions/add-on-webhook"
+    },
+    "add-on": {
+      "$ref": "#/definitions/add-on"
+    },
+    "allowed-add-on-service": {
+      "$ref": "#/definitions/allowed-add-on-service"
+    },
+    "app-feature": {
+      "$ref": "#/definitions/app-feature"
+    },
+    "app-setup": {
+      "$ref": "#/definitions/app-setup"
+    },
+    "app-transfer": {
+      "$ref": "#/definitions/app-transfer"
+    },
+    "app-webhook-delivery": {
+      "$ref": "#/definitions/app-webhook-delivery"
+    },
+    "app-webhook-event": {
+      "$ref": "#/definitions/app-webhook-event"
+    },
+    "app-webhook": {
+      "$ref": "#/definitions/app-webhook"
+    },
+    "app": {
+      "$ref": "#/definitions/app"
+    },
+    "archive": {
+      "$ref": "#/definitions/archive"
+    },
+    "audit-trail-event": {
+      "$ref": "#/definitions/audit-trail-event"
+    },
+    "build": {
+      "$ref": "#/definitions/build"
+    },
+    "buildpack-installation": {
+      "$ref": "#/definitions/buildpack-installation"
+    },
+    "collaborator": {
+      "$ref": "#/definitions/collaborator"
+    },
+    "config-var": {
+      "$ref": "#/definitions/config-var"
+    },
+    "credit": {
+      "$ref": "#/definitions/credit"
+    },
+    "domain": {
+      "$ref": "#/definitions/domain"
+    },
+    "dyno-size": {
+      "$ref": "#/definitions/dyno-size"
+    },
+    "dyno": {
+      "$ref": "#/definitions/dyno"
+    },
+    "enterprise-account-daily-usage": {
+      "$ref": "#/definitions/enterprise-account-daily-usage"
+    },
+    "enterprise-account-member": {
+      "$ref": "#/definitions/enterprise-account-member"
+    },
+    "enterprise-account-monthly-usage": {
+      "$ref": "#/definitions/enterprise-account-monthly-usage"
+    },
+    "enterprise-account": {
+      "$ref": "#/definitions/enterprise-account"
+    },
+    "filter-apps": {
+      "$ref": "#/definitions/filter-apps"
+    },
+    "formation": {
+      "$ref": "#/definitions/formation"
+    },
+    "generation": {
+      "$ref": "#/definitions/generation"
+    },
+    "identity-provider": {
+      "$ref": "#/definitions/identity-provider"
+    },
+    "inbound-ruleset": {
+      "$ref": "#/definitions/inbound-ruleset"
+    },
+    "invoice-address": {
+      "$ref": "#/definitions/invoice-address"
+    },
+    "invoice": {
+      "$ref": "#/definitions/invoice"
+    },
+    "key": {
+      "$ref": "#/definitions/key"
+    },
+    "log-drain": {
+      "$ref": "#/definitions/log-drain"
+    },
+    "log-session": {
+      "$ref": "#/definitions/log-session"
+    },
+    "oauth-authorization": {
+      "$ref": "#/definitions/oauth-authorization"
+    },
+    "oauth-client": {
+      "$ref": "#/definitions/oauth-client"
+    },
+    "oauth-grant": {
+      "$ref": "#/definitions/oauth-grant"
+    },
+    "oauth-token": {
+      "$ref": "#/definitions/oauth-token"
+    },
+    "oci-image": {
+      "$ref": "#/definitions/oci-image"
+    },
+    "password-reset": {
+      "$ref": "#/definitions/password-reset"
+    },
+    "peering-info": {
+      "$ref": "#/definitions/peering-info"
+    },
+    "peering": {
+      "$ref": "#/definitions/peering"
+    },
+    "permission-entity": {
+      "$ref": "#/definitions/permission-entity"
+    },
+    "pipeline-build": {
+      "$ref": "#/definitions/pipeline-build"
+    },
+    "pipeline-config-var": {
+      "$ref": "#/definitions/pipeline-config-var"
+    },
+    "pipeline-coupling": {
+      "$ref": "#/definitions/pipeline-coupling"
+    },
+    "pipeline-deployment": {
+      "$ref": "#/definitions/pipeline-deployment"
+    },
+    "pipeline-promotion-target": {
+      "$ref": "#/definitions/pipeline-promotion-target"
+    },
+    "pipeline-promotion": {
+      "$ref": "#/definitions/pipeline-promotion"
+    },
+    "pipeline-release": {
+      "$ref": "#/definitions/pipeline-release"
+    },
+    "pipeline-stack": {
+      "$ref": "#/definitions/pipeline-stack"
+    },
+    "pipeline-transfer": {
+      "$ref": "#/definitions/pipeline-transfer"
+    },
+    "pipeline": {
+      "$ref": "#/definitions/pipeline"
+    },
+    "plan": {
+      "$ref": "#/definitions/plan"
+    },
+    "rate-limit": {
+      "$ref": "#/definitions/rate-limit"
+    },
+    "region": {
+      "$ref": "#/definitions/region"
+    },
+    "release": {
+      "$ref": "#/definitions/release"
+    },
+    "review-app": {
+      "$ref": "#/definitions/review-app"
+    },
+    "review-app-config": {
+      "$ref": "#/definitions/review-app-config"
+    },
+    "slug": {
+      "$ref": "#/definitions/slug"
+    },
+    "sms-number": {
+      "$ref": "#/definitions/sms-number"
+    },
+    "sni-endpoint": {
+      "$ref": "#/definitions/sni-endpoint"
+    },
+    "source": {
+      "$ref": "#/definitions/source"
+    },
+    "space-app-access": {
+      "$ref": "#/definitions/space-app-access"
+    },
+    "space-nat": {
+      "$ref": "#/definitions/space-nat"
+    },
+    "space-topology": {
+      "$ref": "#/definitions/space-topology"
+    },
+    "space-transfer": {
+      "$ref": "#/definitions/space-transfer"
+    },
+    "space": {
+      "$ref": "#/definitions/space"
+    },
+    "stack": {
+      "$ref": "#/definitions/stack"
+    },
+    "team-add-on": {
+      "$ref": "#/definitions/team-add-on"
+    },
+    "team-app-collaborator": {
+      "$ref": "#/definitions/team-app-collaborator"
+    },
+    "team-app-permission": {
+      "$ref": "#/definitions/team-app-permission"
+    },
+    "team-app": {
+      "$ref": "#/definitions/team-app"
+    },
+    "team-daily-usage": {
+      "$ref": "#/definitions/team-daily-usage"
+    },
+    "team-delinquency": {
+      "$ref": "#/definitions/team-delinquency"
+    },
+    "team-feature": {
+      "$ref": "#/definitions/team-feature"
+    },
+    "team-invitation": {
+      "$ref": "#/definitions/team-invitation"
+    },
+    "team-invoice": {
+      "$ref": "#/definitions/team-invoice"
+    },
+    "team-member": {
+      "$ref": "#/definitions/team-member"
+    },
+    "team-monthly-usage": {
+      "$ref": "#/definitions/team-monthly-usage"
+    },
+    "team-preferences": {
+      "$ref": "#/definitions/team-preferences"
+    },
+    "team-space": {
+      "$ref": "#/definitions/team-space"
+    },
+    "team": {
+      "$ref": "#/definitions/team"
+    },
+    "telemetry-drain": {
+      "$ref": "#/definitions/telemetry-drain"
+    },
+    "test-case": {
+      "$ref": "#/definitions/test-case"
+    },
+    "test-node": {
+      "$ref": "#/definitions/test-node"
+    },
+    "test-run": {
+      "$ref": "#/definitions/test-run"
+    },
+    "user-preferences": {
+      "$ref": "#/definitions/user-preferences"
+    },
+    "vpn-connection": {
+      "$ref": "#/definitions/vpn-connection"
+    }
+  },
+  "description": "The platform API empowers developers to automate, extend and combine Heroku with other services.",
+  "id": "http://api.heroku.com/schema#",
+  "links": [
+    {
+      "href": "https://api.heroku.com",
+      "rel": "self",
+      "title": "Index"
+    },
+    {
+      "href": "/schema",
+      "method": "GET",
+      "rel": "self",
+      "title": "Schema",
+      "targetSchema": {
+        "additionalProperties": true
+      }
+    }
+  ],
+  "title": "Heroku Platform API"
+}


### PR DESCRIPTION
Includes the python script for converting Heroku's JSON Schema into OpenAPI YAML specs.
Also adds the generated OpenAPI .yaml files.